### PR TITLE
Add initial implementation of the TwiML generation package, twiml

### DIFF
--- a/twiml/barge_in.go
+++ b/twiml/barge_in.go
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import "encoding/xml"
+
+// BargeIn allows you to specify if Twilio should stop playing media from nested
+// or verbs once Twilio receives speech or DTMF. Defaults to true.
+type BargeIn uint8
+
+const (
+	// BargeInTrue sets BargeIn to true.
+	BargeInTrue BargeIn = 1 << iota
+
+	// BargeInFalse sets BargeIn to false.
+	BargeInFalse
+)
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (b BargeIn) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: b.String(),
+	}
+
+	return attr, nil
+}
+
+// Bool returns the boolean representation of the BargeIn value. If the value is
+// not explicitly false, it's assumed true (to match Twilio's default).
+func (b BargeIn) Bool() bool {
+	if b == BargeInFalse {
+		return false
+	}
+
+	return true
+}
+
+func (b BargeIn) String() string {
+	switch b {
+	case BargeInTrue:
+		return "true"
+	case BargeInFalse:
+		return "false"
+	default:
+		return ""
+	}
+}

--- a/twiml/barge_in_test.go
+++ b/twiml/barge_in_test.go
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestBargeIn_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   BargeIn
+		out  string
+	}{
+		{"Default (Zero Value) BargeIn should return empty-string", BargeIn(0), ""},
+		{"BargeInTrue should be true", BargeInTrue, "true"},
+		{"BargeInFalse should be false", BargeInFalse, "false"},
+	}
+
+	for _, test := range tests {
+		if out := test.in.String(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestBargeIn_Bool(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   BargeIn
+		out  bool
+	}{
+		{"Default (Zero Value) BargeIn should return true", BargeIn(0), true},
+		{"BargeInTrue should be true", BargeInTrue, true},
+		{"BargeInFalse should be false", BargeInFalse, false},
+		{"An Unknown BargeIn value should return true", BargeIn(^uint8(0)), true},
+	}
+
+	for _, test := range tests {
+		if out := test.in.Bool(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).Bool() = %v; want %v",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestBargeIn_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "trim"}
+
+	tests := []struct {
+		desc     string
+		in       BargeIn
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Value) BargeIn should return empty-string", BargeIn(0), attrName, attrName, ""},
+		{"BargeInTrue should be true", BargeInTrue, attrName, attrName, "true"},
+		{"BargeInFalse should be false", BargeInFalse, attrName, attrName, "false"},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}

--- a/twiml/conf_beep.go
+++ b/twiml/conf_beep.go
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import "encoding/xml"
+
+// ConfBeep allows you to specify if Twilio lets you specify whether a
+// notification beep is played to the conference when a participant joins or
+// leaves the conference.
+type ConfBeep uint8
+
+const (
+	// ConfBeepTrue sets ConfBeep to true.
+	ConfBeepTrue ConfBeep = 1 << iota
+
+	// ConfBeepFalse sets ConfBeep to false.
+	ConfBeepFalse
+)
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (b ConfBeep) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: b.String(),
+	}
+
+	return attr, nil
+}
+
+// Bool returns the boolean representation of the ConfBeep value. If the value is
+// not explicitly false, it's assumed true (to match Twilio's default).
+func (b ConfBeep) Bool() bool {
+	if b == ConfBeepFalse {
+		return false
+	}
+
+	return true
+}
+
+func (b ConfBeep) String() string {
+	switch b {
+	case ConfBeepTrue:
+		return "true"
+	case ConfBeepFalse:
+		return "false"
+	default:
+		return ""
+	}
+}

--- a/twiml/conf_beep_test.go
+++ b/twiml/conf_beep_test.go
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestConfBeep_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   ConfBeep
+		out  string
+	}{
+		{"Default (Zero Value) ConfBeep should return empty-string", ConfBeep(0), ""},
+		{"ConfBeepTrue should be true", ConfBeepTrue, "true"},
+		{"ConfBeepFalse should be false", ConfBeepFalse, "false"},
+	}
+
+	for _, test := range tests {
+		if out := test.in.String(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestConfBeep_Bool(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   ConfBeep
+		out  bool
+	}{
+		{"Default (Zero Value) ConfBeep should return true", ConfBeep(0), true},
+		{"ConfBeepTrue should be true", ConfBeepTrue, true},
+		{"ConfBeepFalse should be false", ConfBeepFalse, false},
+		{"An Unknown ConfBeep value should return true", ConfBeep(^uint8(0)), true},
+	}
+
+	for _, test := range tests {
+		if out := test.in.Bool(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).Bool() = %v; want %v",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestConfBeep_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "trim"}
+
+	tests := []struct {
+		desc     string
+		in       ConfBeep
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Value) ConfBeep should return empty-string", ConfBeep(0), attrName, attrName, ""},
+		{"ConfBeepTrue should be true", ConfBeepTrue, attrName, attrName, "true"},
+		{"ConfBeepFalse should be false", ConfBeepFalse, attrName, attrName, "false"},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}

--- a/twiml/conf_record.go
+++ b/twiml/conf_record.go
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import "encoding/xml"
+
+// ConfRecord lets you record an entire conference.
+type ConfRecord uint8
+
+const (
+	// ConfDoNotRecord disables recording.
+	ConfDoNotRecord ConfRecord = 1 << iota
+
+	// ConfRecordFromStart tells Twilio to record the conference from when the
+	// first two participants are bridged. The hold music is never recorded.
+	ConfRecordFromStart
+)
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (r ConfRecord) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: r.String(),
+	}
+
+	return attr, nil
+}
+
+func (r ConfRecord) String() string {
+	switch r {
+	case ConfDoNotRecord:
+		return "do-not-record"
+	case ConfRecordFromStart:
+		return "record-from-start"
+	default:
+		return ""
+	}
+}

--- a/twiml/conf_record_test.go
+++ b/twiml/conf_record_test.go
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestConfRecord_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   ConfRecord
+		out  string
+	}{
+		{"Default (Zero Value) ConfRecord should return empty-string", ConfRecord(0), ""},
+		{"ConfDoNotRecord should return do-not-record", ConfDoNotRecord, "do-not-record"},
+		{"ConfRecordFromStart should return record-from-start", ConfRecordFromStart, "record-from-start"},
+	}
+
+	for _, test := range tests {
+		if out := test.in.String(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestConfRecord_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "trim"}
+
+	tests := []struct {
+		desc     string
+		in       ConfRecord
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Value) ConfRecord should return empty-string", ConfRecord(0), attrName, attrName, ""},
+		{"ConfDoNotRecord should return do-not-record", ConfDoNotRecord, attrName, attrName, "do-not-record"},
+		{"ConfRecordFromStart should return record-from-start", ConfRecordFromStart, attrName, attrName, "record-from-start"},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}

--- a/twiml/conf_region.go
+++ b/twiml/conf_region.go
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import "encoding/xml"
+
+// ConfRegion specifies the region where Twilio should mix the conference.
+// Specifying a value for region overrides Twilio's automatic region selection
+// logic and should only be used if you are confident you understand where your
+// conferences should be mixed. Twilio sets the region parameter from the first
+// participant that specifies the parameter and will ignore the parameter from
+// subsequent participants.
+type ConfRegion uint16
+
+const (
+	// ConfRegionAustralia sets ConfRegion to Australia.
+	ConfRegionAustralia ConfRegion = 1 << iota
+
+	// ConfRegionBrazil sets ConfRegion to Brazil.
+	ConfRegionBrazil
+
+	// ConfRegionIreland sets ConfRegion to Ireland.
+	ConfRegionIreland
+
+	// ConfRegionJapan sets ConfRegion to Japan.
+	ConfRegionJapan
+
+	// ConfRegionSingapore sets ConfRegion to Singapore.
+	ConfRegionSingapore
+
+	// ConfRegionUS sets ConfRegion to the United States.
+	ConfRegionUS
+)
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (r ConfRegion) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: r.String(),
+	}
+
+	return attr, nil
+}
+
+func (r ConfRegion) String() string {
+	switch r {
+	case ConfRegionAustralia:
+		return "au1"
+	case ConfRegionBrazil:
+		return "br1"
+	case ConfRegionIreland:
+		return "ie1"
+	case ConfRegionJapan:
+		return "jp1"
+	case ConfRegionSingapore:
+		return "sg1"
+	case ConfRegionUS:
+		return "us1"
+	default:
+		return ""
+	}
+}

--- a/twiml/conf_region_test.go
+++ b/twiml/conf_region_test.go
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestConfRegion_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   ConfRegion
+		out  string
+	}{
+		{"Default (Zero Value) ConfRegion should return empty-string", ConfRegion(0), ""},
+		{"ConfRegionAustralia should return Australia", ConfRegionAustralia, "au1"},
+		{"ConfRegionBrazil should return Brazil", ConfRegionBrazil, "br1"},
+		{"ConfRegionIreland should return Ireland", ConfRegionIreland, "ie1"},
+		{"ConfRegionJapan should return Japan", ConfRegionJapan, "jp1"},
+		{"ConfRegionSingapore should return Singapore", ConfRegionSingapore, "sg1"},
+		{"ConfRegionUS should return the United States", ConfRegionUS, "us1"},
+	}
+
+	for _, test := range tests {
+		if out := test.in.String(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestConfRegion_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "trim"}
+
+	tests := []struct {
+		desc     string
+		in       ConfRegion
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Value) ConfRegion should return empty-string", ConfRegion(0), attrName, attrName, ""},
+		{"ConfRegionAustralia should return Australia", ConfRegionAustralia, attrName, attrName, "au1"},
+		{"ConfRegionBrazil should return Brazil", ConfRegionBrazil, attrName, attrName, "br1"},
+		{"ConfRegionIreland should return Ireland", ConfRegionIreland, attrName, attrName, "ie1"},
+		{"ConfRegionJapan should return Japan", ConfRegionJapan, attrName, attrName, "jp1"},
+		{"ConfRegionSingapore should return Singapore", ConfRegionSingapore, attrName, attrName, "sg1"},
+		{"ConfRegionUS should return the United States", ConfRegionUS, attrName, attrName, "us1"},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}

--- a/twiml/conf_start_on_enter_bool.go
+++ b/twiml/conf_start_on_enter_bool.go
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import "encoding/xml"
+
+// ConfStartOnEnterBool tells a conference to start when this participant joins
+// the conference, if it is not already started. This is true by default. If
+// this is false and the participant joins a conference that has not started,
+// they are muted and hear background music until a participant joins where
+// startConferenceOnEnter is true. This is useful for implementing moderated
+// conferences.
+type ConfStartOnEnterBool uint8
+
+const (
+	// ConfStartOnEnterTrue sets ConfStartOnEnterBool to true.
+	ConfStartOnEnterTrue ConfStartOnEnterBool = 1 << iota
+
+	// ConfStartOnEnterFalse sets ConfStartOnEnterBool to false.
+	ConfStartOnEnterFalse
+)
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (s ConfStartOnEnterBool) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: s.String(),
+	}
+
+	return attr, nil
+}
+
+// Bool returns the boolean representation of the ConfStartOnEnterBool value. If the value is
+// not explicitly false, it's assumed true (to match Twilio's default).
+func (s ConfStartOnEnterBool) Bool() bool {
+	if s == ConfStartOnEnterFalse {
+		return false
+	}
+
+	return true
+}
+
+func (s ConfStartOnEnterBool) String() string {
+	switch s {
+	case ConfStartOnEnterTrue:
+		return "true"
+	case ConfStartOnEnterFalse:
+		return "false"
+	default:
+		return ""
+	}
+}

--- a/twiml/conf_start_on_enter_bool_test.go
+++ b/twiml/conf_start_on_enter_bool_test.go
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestConfStartOnEnterBool_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   ConfStartOnEnterBool
+		out  string
+	}{
+		{"Default (Zero Value) ConfStartOnEnterBool should return empty-string", ConfStartOnEnterBool(0), ""},
+		{"ConfStartOnEnterTrue should be true", ConfStartOnEnterTrue, "true"},
+		{"ConfStartOnEnterFalse should be false", ConfStartOnEnterFalse, "false"},
+	}
+
+	for _, test := range tests {
+		if out := test.in.String(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestConfStartOnEnterBool_Bool(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   ConfStartOnEnterBool
+		out  bool
+	}{
+		{"Default (Zero Value) ConfStartOnEnterBool should return true", ConfStartOnEnterBool(0), true},
+		{"ConfStartOnEnterTrue should be true", ConfStartOnEnterTrue, true},
+		{"ConfStartOnEnterFalse should be false", ConfStartOnEnterFalse, false},
+		{"An Unknown ConfStartOnEnterBool value should return true", ConfStartOnEnterBool(^uint8(0)), true},
+	}
+
+	for _, test := range tests {
+		if out := test.in.Bool(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).Bool() = %v; want %v",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestConfStartOnEnterBool_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "trim"}
+
+	tests := []struct {
+		desc     string
+		in       ConfStartOnEnterBool
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Value) ConfStartOnEnterBool should return empty-string", ConfStartOnEnterBool(0), attrName, attrName, ""},
+		{"ConfStartOnEnterTrue should be true", ConfStartOnEnterTrue, attrName, attrName, "true"},
+		{"ConfStartOnEnterFalse should be false", ConfStartOnEnterFalse, attrName, attrName, "false"},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}

--- a/twiml/conf_status_callback_event.go
+++ b/twiml/conf_status_callback_event.go
@@ -1,0 +1,122 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"bytes"
+	"encoding/xml"
+)
+
+// ConfStatusCallbackEvent allows you to specify if Twilio lets you specify whether a
+// notification beep is played to the conference when a participant joins or
+// leaves the conference.
+type ConfStatusCallbackEvent uint16
+
+const (
+	// ConfStatusCallbackStart is when the conference has begun and audio is
+	// being mixed between all participants. This occurs when there is at least
+	// one participant in the conference and a participant with
+	// startConferenceOnEnter="true" joins.
+	ConfStatusCallbackStart ConfStatusCallbackEvent = 1 << iota
+
+	// ConfStatusCallbackEnd is when the last participant has left the
+	// conference or a participant with endConferenceOnExit="true" leaves the
+	// conference.
+	ConfStatusCallbackEnd
+
+	// ConfStatusCallbackJoin is when a participant has joined the conference.
+	ConfStatusCallbackJoin
+
+	// ConfStatusCallbackLeave is when a participant has left the conference.
+	ConfStatusCallbackLeave
+
+	// ConfStatusCallbackMute is when a participant has been muted or unmuted.
+	ConfStatusCallbackMute
+
+	// ConfStatusCallbackHold is for when a participant has been held or unheld.
+	ConfStatusCallbackHold // Hold me closer, Tony Danza
+
+	// ConfStatusCallbackSpeaker is for when a participant has started or
+	// stopped speaking.
+	ConfStatusCallbackSpeaker
+)
+
+// ConfStatusCallbackAll is a constant value that encompasses all ConfStatusCallbackEvent values.
+const ConfStatusCallbackAll = ConfStatusCallbackStart | ConfStatusCallbackEnd | ConfStatusCallbackJoin |
+	ConfStatusCallbackLeave | ConfStatusCallbackMute | ConfStatusCallbackHold | ConfStatusCallbackSpeaker
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (s ConfStatusCallbackEvent) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: s.String(),
+	}
+
+	return attr, nil
+}
+
+func (s ConfStatusCallbackEvent) String() string {
+	if s == ConfStatusCallbackEvent(0) {
+		return ""
+	}
+
+	buf := bufferPool.Get().(*bytes.Buffer)
+
+	defer bufferPool.Put(buf)
+	defer buf.Reset()
+
+	if s&ConfStatusCallbackStart == ConfStatusCallbackStart {
+		if buf.Len() > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString("start")
+	}
+
+	if s&ConfStatusCallbackEnd == ConfStatusCallbackEnd {
+		if buf.Len() > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString("end")
+	}
+
+	if s&ConfStatusCallbackJoin == ConfStatusCallbackJoin {
+		if buf.Len() > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString("join")
+	}
+
+	if s&ConfStatusCallbackLeave == ConfStatusCallbackLeave {
+		if buf.Len() > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString("leave")
+	}
+
+	if s&ConfStatusCallbackMute == ConfStatusCallbackMute {
+		if buf.Len() > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString("mute")
+	}
+
+	if s&ConfStatusCallbackHold == ConfStatusCallbackHold {
+		if buf.Len() > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString("hold")
+	}
+
+	if s&ConfStatusCallbackSpeaker == ConfStatusCallbackSpeaker {
+		if buf.Len() > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString("speaker")
+	}
+
+	return buf.String()
+}

--- a/twiml/conf_status_callback_event_test.go
+++ b/twiml/conf_status_callback_event_test.go
@@ -1,0 +1,91 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestConfStatusCallbackEvent_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   ConfStatusCallbackEvent
+		out  string
+	}{
+		{"Default (Zero Value) ConfStatusCallbackEvent should return empty-string", ConfStatusCallbackEvent(0), ""},
+		{"ConfStatusCallbackEnd should return the end value", ConfStatusCallbackEnd, "end"},
+		{"ConfStatusCallbackEnd should return the end value", ConfStatusCallbackEnd, "end"},
+		{"ConfStatusCallbackJoin should return the join value", ConfStatusCallbackJoin, "join"},
+		{"ConfStatusCallbackLeave should return the leave value", ConfStatusCallbackLeave, "leave"},
+		{"ConfStatusCallbackMute should return the mute value", ConfStatusCallbackMute, "mute"},
+		{"ConfStatusCallbackHold should return the hold value", ConfStatusCallbackHold, "hold"},
+		{"ConfStatusCallbackSpeaker should return the speaker value", ConfStatusCallbackSpeaker, "speaker"},
+		{"ConfStatusCallbackStart | ConfStatusCallbackEnd | ConfStatusCallbackJoin should return the start, end, and join values", ConfStatusCallbackStart | ConfStatusCallbackEnd | ConfStatusCallbackJoin, "start end join"},
+		{"ConfStatusCallbackAll should return all values", ConfStatusCallbackAll, "start end join leave mute hold speaker"},
+	}
+
+	for _, test := range tests {
+		if out := test.in.String(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestConfStatusCallbackEvent_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "trim"}
+
+	tests := []struct {
+		desc     string
+		in       ConfStatusCallbackEvent
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Value) ConfStatusCallbackEvent should return empty-string", ConfStatusCallbackEvent(0), attrName, attrName, ""},
+		{"ConfStatusCallbackEnd should return the end value", ConfStatusCallbackEnd, attrName, attrName, "end"},
+		{"ConfStatusCallbackEnd should return the end value", ConfStatusCallbackEnd, attrName, attrName, "end"},
+		{"ConfStatusCallbackJoin should return the join value", ConfStatusCallbackJoin, attrName, attrName, "join"},
+		{"ConfStatusCallbackLeave should return the leave value", ConfStatusCallbackLeave, attrName, attrName, "leave"},
+		{"ConfStatusCallbackMute should return the mute value", ConfStatusCallbackMute, attrName, attrName, "mute"},
+		{"ConfStatusCallbackHold should return the hold value", ConfStatusCallbackHold, attrName, attrName, "hold"},
+		{"ConfStatusCallbackSpeaker should return the speaker value", ConfStatusCallbackSpeaker, attrName, attrName, "speaker"},
+		{"ConfStatusCallbackStart | ConfStatusCallbackEnd | ConfStatusCallbackJoin should return the start, end, and join values", ConfStatusCallbackStart | ConfStatusCallbackEnd | ConfStatusCallbackJoin, attrName, attrName, "start end join"},
+		{"ConfStatusCallbackAll should return all values", ConfStatusCallbackAll, attrName, attrName, "start end join leave mute hold speaker"},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}

--- a/twiml/dial_nouns.go
+++ b/twiml/dial_nouns.go
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import "encoding/xml"
+
+// The DialClient noun is meant to be used as a Dial.Noun and it specifies a
+// client identifier to dial.
+//
+// You can use up to ten Client nouns within a Dial verb to simultaneously
+// attempt a connection with many clients at once. The first client to accept
+// the incoming connection is connected to the call and the other connection
+// attempts are canceled. If you want to connect with multiple other clients
+// simultaneously, read about the Conference noun.
+type DialClient struct {
+	XMLName              xml.Name            `xml:"Client"`
+	ClientName           string              `xml:",chardata"`
+	URL                  string              `xml:"url,attr,omitempty"`
+	Method               string              `xml:"method,attr,omitempty"`
+	StatusCallbackEvent  StatusCallbackEvent `xml:"statusCallbackEvent,attr,omitempty"`
+	StatusCallback       string              `xml:"statusCallback,attr,omitempty"`
+	StatusCallbackMethod string              `xml:"statusCallbackMethod,attr,omitempty"`
+}
+
+// The DialConference noun is meant to be used as a Dial.Noun and it allows you
+// to connect to a conference room. Much like how the DialNumber noun allows you
+// to connect to another phone number, the DialConference noun allows you to connect
+// to a named conference room and talk with the other callers who have also
+// connected to that room. Conference is commonly used as a container for calls
+// when implementing hold, transfer, and barge.
+type DialConference struct {
+	XMLName                       xml.Name                `xml:"Conference"`
+	Name                          string                  `xml:",chardata"`
+	Muted                         bool                    `xml:"muted,attr"`
+	Beep                          ConfBeep                `xml:"beep,attr,omitempty"`
+	StartConferenceOnEnter        ConfStartOnEnterBool    `xml:"startConferenceOnEnter,attr,omitempty"`
+	EndConferenceOnExit           bool                    `xml:"endConferenceOnExit,attr"`
+	WaitURL                       string                  `xml:"waitUrl,attr,omitempty"`
+	WaitMethod                    string                  `xml:"waitMethod,attr,omitempty"`
+	MaxParticipants               uint16                  `xml:"maxParticipants,attr,omitempty"`
+	Record                        ConfRecord              `xml:"record,attr,omitempty"`
+	Region                        ConfRegion              `xml:"region,attr,omitempty"`
+	Trim                          Trim                    `xml:"trim,attr,omitempty"`
+	Whisper                       string                  `xml:"whisper,attr,omitempty"`
+	StatusCallbackEvent           ConfStatusCallbackEvent `xml:"statusCallbackEvent,attr,omitempty"`
+	StatusCallback                string                  `xml:"statusCallback,attr,omitempty"`
+	StatusCallbackMethod          string                  `xml:"statusCallbackMethod,attr,omitempty"`
+	RecordingStatusCallback       string                  `xml:"recordingStatusCallback,attr,omitempty"`
+	RecordingStatusCallbackMethod string                  `xml:"recordingStatusCallbackMethod,attr,omitempty"`
+}
+
+// The DialNumber noun is meant to be used as a Dial.Noun and it specifies a
+// phone number to dial. Using the noun's attributes you can specify particular
+// behaviors that Twilio should apply when dialing the number.
+type DialNumber struct {
+	XMLName              xml.Name            `xml:"Number"`
+	Number               string              `xml:",chardata"`
+	SendDigits           string              `xml:"sendDigits,attr,omitempty"`
+	URL                  string              `xml:"url,attr,omitempty"`
+	Method               string              `xml:"method,attr,omitempty"`
+	StatusCallbackEvent  StatusCallbackEvent `xml:"statusCallbackEvent,attr,omitempty"`
+	StatusCallback       string              `xml:"statusCallback,attr,omitempty"`
+	StatusCallbackMethod string              `xml:"statusCallbackMethod,attr,omitempty"`
+}
+
+// The DialQueue noun is meant to be used as a Dial.Noun and it specifies a
+// queue to dial. When dialing a queue, the caller will be connected with the
+// first enqueued call in the specified queue. If the queue is empty, Dial will
+// wait until the next person joins the queue or until the timeout duration is
+// reached. If the queue does not exist, Dial will post an error status to its
+// URL.
+type DialQueue struct {
+	XMLName             xml.Name `xml:"Queue"`
+	QueueName           string   `xml:",chardata"`
+	URL                 string   `xml:"url,attr,omitempty"`
+	Method              string   `xml:"method,attr,omitempty"`
+	ReservationSID      string   `xml:"reservationSid,attr,omitempty"`
+	PostWorkActivitySID string   `xml:"postWorkActivitySid,attr,omitempty"`
+}
+
+// The DialSIM noun is meant to be used as a Dial.Noun and it specifies a
+// Programmable Wireless SIM to dial.
+type DialSIM struct {
+	XMLName xml.Name `xml:"Sim"`
+	SIM     string   `xml:",chardata"`
+}
+
+// The DialSIP noun is meant to be used as a Dial.Noun and it lets you set up
+// VoIP sessions by using SIP -- Session Initiation Protocol. With this feature,
+// you can send a call to any SIP endpoint.
+type DialSIP struct {
+	XMLName  xml.Name `xml:"Sip"`
+	URI      string   `xml:",chardata"`
+	Username string   `xml:"username,attr,omitempty"`
+	Password string   `xml:"password,attr,omitempty"`
+
+	// URL is the call screening URL for the SIP call
+	// With Method being the HTTP method used for hitting the URL
+	URL    string `xml:"url,attr,omitempty"`
+	Method string `xml:"method,attr,omitempty"`
+
+	StatusCallbackEvent  StatusCallbackEvent `xml:"statusCallbackEvent,attr,omitempty"`
+	StatusCallback       string              `xml:"statusCallback,attr,omitempty"`
+	StatusCallbackMethod string              `xml:"statusCallbackMethod,attr,omitempty"`
+
+	//
+	// Attributes shared from Dial verb
+	//
+	// Action                        string     `xml:"action,attr,omitempty"`
+	// Method                        string     `xml:"method,attr,omitempty"`
+	Timeout                       uint       `xml:"timeout,attr,omitempty"`
+	HangupOnStar                  bool       `xml:"hangupOnStar,attr"`
+	TimeLimit                     uint       `xml:"timeLimit,attr,omitempty"`
+	CallerID                      string     `xml:"callerId,attr,omitempty"`
+	Record                        DialRecord `xml:"record,attr,omitempty"`
+	Trim                          Trim       `xml:"trim,attr,omitempty"`
+	RecordingStatusCallback       string     `xml:"recordingStatusCallback,attr,omitempty"`
+	RecordingStatusCallbackMethod string     `xml:"recordingStatusCallbackMethod,attr,omitempty"`
+	AnswerOnBridge                bool       `xml:"answerOnBridge,attr"`
+	RingTone                      RingTone   `xml:"ringTone,attr,omitempty"`
+}

--- a/twiml/dial_record.go
+++ b/twiml/dial_record.go
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import "encoding/xml"
+
+// DialRecord lets you record both legs of a call within the associated Dial verb. Recordings are available in two options: mono-channel or dual-channel.
+type DialRecord uint8
+
+const (
+	// DialDoNotRecord disables recording.
+	DialDoNotRecord DialRecord = 1 << iota
+
+	// DialRecordFromAnswerMono is the mono-channel recording from the call being
+	// answered.
+	DialRecordFromAnswerMono
+
+	// DialRecordFromRingingMono is the mono-channel recording from the call
+	// starting to ring.
+	DialRecordFromRingingMono
+
+	// DialRecordFromAnswerDual is the dual-channel recording from the call being
+	// answered.
+	DialRecordFromAnswerDual
+
+	// DialRecordFromRingingDual is the dual-channel recording from the call
+	// starting to ring.
+	DialRecordFromRingingDual
+)
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (d DialRecord) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: d.String(),
+	}
+
+	return attr, nil
+}
+
+func (d DialRecord) String() string {
+	switch d {
+	case DialDoNotRecord:
+		return "do-not-record"
+	case DialRecordFromAnswerMono:
+		return "record-from-answer"
+	case DialRecordFromRingingMono:
+		return "record-from-ringing"
+	case DialRecordFromAnswerDual:
+		return "record-from-answer-dual"
+	case DialRecordFromRingingDual:
+		return "record-from-ringing-dual"
+	default:
+		return ""
+	}
+}

--- a/twiml/dial_record_test.go
+++ b/twiml/dial_record_test.go
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestDialRecord_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   DialRecord
+		out  string
+	}{
+		{"Default (Zero Value) DialRecord should return empty-string", DialRecord(0), ""},
+		{"DialDoNotRecord should return do-not-record", DialDoNotRecord, "do-not-record"},
+		{"DialRecordFromAnswerMono should return record-from-answer", DialRecordFromAnswerMono, "record-from-answer"},
+		{"DialRecordFromRingingMono should return record-from-ringing", DialRecordFromRingingMono, "record-from-ringing"},
+		{"DialRecordFromAnswerDual should return record-from-answer-dual", DialRecordFromAnswerDual, "record-from-answer-dual"},
+		{"DialRecordFromRingingDual should return record-from-ringing-dual", DialRecordFromRingingDual, "record-from-ringing-dual"},
+	}
+
+	for _, test := range tests {
+		if out := test.in.String(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestDialRecord_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "trim"}
+
+	tests := []struct {
+		desc     string
+		in       DialRecord
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Value) DialRecord should return empty-string", DialRecord(0), attrName, attrName, ""},
+		{"DialDoNotRecord should return do-not-record", DialDoNotRecord, attrName, attrName, "do-not-record"},
+		{"DialRecordFromAnswerMono should return record-from-answer", DialRecordFromAnswerMono, attrName, attrName, "record-from-answer"},
+		{"DialRecordFromRingingMono should return record-from-ringing", DialRecordFromRingingMono, attrName, attrName, "record-from-ringing"},
+		{"DialRecordFromAnswerDual should return record-from-answer-dual", DialRecordFromAnswerDual, attrName, attrName, "record-from-answer-dual"},
+		{"DialRecordFromRingingDual should return record-from-ringing-dual", DialRecordFromRingingDual, attrName, attrName, "record-from-ringing-dual"},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}

--- a/twiml/doc.go
+++ b/twiml/doc.go
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+// Package twiml provides support for generating Twilio Markup Language (TwiML).
+// TwiML is an XML document that uses tags and attributes to instruct Twilio on
+// how to process a phone call. The TwiML instructions can be applied to
+// outbound calls (calls you've dialed), or inbound calls (calls that dialed
+// your Twilio number).
+//
+// Most of the contents of this package are custom types (structs, or other) to
+// allow us to generate documents that meet the requirements of a TwiML document
+// in a Go-like fashion. One of the biggest features of this package is to
+// provide types and constants that enable certain functionality or render
+// certain attributes. This means you can use the client, and have code
+// completion work for you, without needing to remember the string value that
+// the TwiML parser expects. One example is the Trim type and its constants,
+// where we translate the value to the string representation in TwiML (e.g.,
+// DoNotTrim becomes "do-not-trim").
+//
+// It's worth noting that this package does not do deep validation of TwiML
+// documents you are attempting to render. In other words if you try to render
+// an invalid TwiML document, by trying to place a Redirect verb within a Gather
+// verb for example, this package will happily render the document. However,
+// Twilio will fail to parse this document as it is invalid per the spec.
+//
+// There are a few functions available to you for rendering out TwiML, with the
+// main being EncodeResponse(). All of the other functions end up calling
+// EncodeResponse() under the hood. If you aren't sending the data to an
+// io.Writer interface, which is what EncodeResponse() expects, there is a
+// MarshalResponse() function which returns a byte slice instead. There are also
+// functions to work with slices of verbs instead of a full instance of
+// *Response.
+//
+// Here is a simple example of using EncodeResponse():
+//
+// 		buf := &bytes.Buffer{}
+// 		say := &twiml.Say{Message: "Hi there!"}
+// 		resp := &twiml.Response{Verbs: []interface{}{say}}
+// 		if err := twiml.EncodeResponse(buf, resp); err != nil {
+// 			panic(err) // handle this better, though
+// 		}
+// 		fmt.Println(buf.String())
+//
+// The above code should render the following XML document:
+//
+// 		<?xml version="1.0" encoding="UTF-8"?>
+// 		<Response>
+// 		  <Say>Hi there!</Say>
+// 		</Response>
+package twiml

--- a/twiml/finish_on_key.go
+++ b/twiml/finish_on_key.go
@@ -1,0 +1,148 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"bytes"
+	"encoding/xml"
+)
+
+// FinishOnKey is a type for defining which digits will end a recording when
+// pressed. This is a bit-flag type, with constants defined for each number.
+// You use the bitwise OR operator (|) to enable specific buttons.
+type FinishOnKey uint16
+
+const (
+	// FinishKeyNumber0 is the equivalent to someone pressing the number 0 on
+	// their keypad to end a recording.
+	FinishKeyNumber0 FinishOnKey = 1 << iota
+
+	// FinishKeyNumber1 is the equivalent to someone pressing the number 1 on
+	// their keypad to end a recording.
+	FinishKeyNumber1
+
+	// FinishKeyNumber2 is the equivalent to someone pressing the number 2 on
+	// their keypad to end a recording.
+	FinishKeyNumber2
+
+	// FinishKeyNumber3 is the equivalent to someone pressing the number 3 on
+	// their keypad to end a recording.
+	FinishKeyNumber3
+
+	// FinishKeyNumber4 is the equivalent to someone pressing the number 4 on
+	// their keypad to end a recording.
+	FinishKeyNumber4
+
+	// FinishKeyNumber5 is the equivalent to someone pressing the number 5 on
+	// their keypad to end a recording.
+	FinishKeyNumber5
+
+	// FinishKeyNumber6 is the equivalent to someone pressing the number 6 on
+	// their keypad to end a recording.
+	FinishKeyNumber6
+
+	// FinishKeyNumber7 is the equivalent to someone pressing the number 7 on
+	// their keypad to end a recording.
+	FinishKeyNumber7
+
+	// FinishKeyNumber8 is the equivalent to someone pressing the number 8 on
+	// their keypad to end a recording.
+	FinishKeyNumber8
+
+	// FinishKeyNumber9 is the equivalent to someone pressing the number 9 on
+	// their keypad to end a recording.
+	FinishKeyNumber9
+
+	// FinishKeyStar is the equivalent to someone pressing the star (*)
+	// button on their keypad to end a recording.
+	FinishKeyStar
+
+	// FinishKeyPound is the equivalent to someone pressing the pound (#) button
+	// on their keypad to end a recording.
+	FinishKeyPound
+
+	// FinishKeyNone is the equivalent of there being no finish key set. This
+	// renders an empty string in the XML attribute.
+	FinishKeyNone
+)
+
+// FinishKeyAll is the combination of all keys together
+const FinishKeyAll = FinishKeyNumber0 | FinishKeyNumber1 | FinishKeyNumber2 |
+	FinishKeyNumber3 | FinishKeyNumber4 | FinishKeyNumber5 | FinishKeyNumber6 |
+	FinishKeyNumber7 | FinishKeyNumber8 | FinishKeyNumber9 | FinishKeyStar |
+	FinishKeyPound
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (f FinishOnKey) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: f.String(),
+	}
+
+	return attr, nil
+}
+
+func (f FinishOnKey) String() string {
+	if f == FinishKeyNone {
+		return ""
+	}
+
+	buf := bufferPool.Get().(*bytes.Buffer)
+
+	defer bufferPool.Put(buf)
+	defer buf.Reset()
+
+	if f&FinishKeyNumber1 == FinishKeyNumber1 {
+		buf.WriteString("1")
+	}
+
+	if f&FinishKeyNumber2 == FinishKeyNumber2 {
+		buf.WriteString("2")
+	}
+
+	if f&FinishKeyNumber3 == FinishKeyNumber3 {
+		buf.WriteString("3")
+	}
+
+	if f&FinishKeyNumber4 == FinishKeyNumber4 {
+		buf.WriteString("4")
+	}
+
+	if f&FinishKeyNumber5 == FinishKeyNumber5 {
+		buf.WriteString("5")
+	}
+
+	if f&FinishKeyNumber6 == FinishKeyNumber6 {
+		buf.WriteString("6")
+	}
+
+	if f&FinishKeyNumber7 == FinishKeyNumber7 {
+		buf.WriteString("7")
+	}
+
+	if f&FinishKeyNumber8 == FinishKeyNumber8 {
+		buf.WriteString("8")
+	}
+
+	if f&FinishKeyNumber9 == FinishKeyNumber9 {
+		buf.WriteString("9")
+	}
+
+	if f&FinishKeyNumber0 == FinishKeyNumber0 {
+		buf.WriteString("0")
+	}
+
+	if f&FinishKeyStar == FinishKeyStar {
+		buf.WriteString("*")
+	}
+
+	if f&FinishKeyPound == FinishKeyPound {
+		buf.WriteString("#")
+	}
+
+	return buf.String()
+}

--- a/twiml/finish_on_key_test.go
+++ b/twiml/finish_on_key_test.go
@@ -1,0 +1,91 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestFinishOnKey_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   FinishOnKey
+		out  string
+	}{
+		{"Invalid FinishOnKey should be empty string", FinishOnKey(0), ""},
+		{"FinishKeyNumber0 should be 0", FinishKeyNumber0, "0"},
+		{"FinishKeyNumber1 should be 1", FinishKeyNumber1, "1"},
+		{"FinishKeyNumber2 should be 2", FinishKeyNumber2, "2"},
+		{"FinishKeyNumber3 should be 3", FinishKeyNumber3, "3"},
+		{"FinishKeyNumber4 should be 4", FinishKeyNumber4, "4"},
+		{"FinishKeyNumber5 should be 5", FinishKeyNumber5, "5"},
+		{"FinishKeyNumber6 should be 6", FinishKeyNumber6, "6"},
+		{"FinishKeyNumber7 should be 7", FinishKeyNumber7, "7"},
+		{"FinishKeyNumber8 should be 8", FinishKeyNumber8, "8"},
+		{"FinishKeyNumber9 should be 9", FinishKeyNumber9, "9"},
+		{"FinishKeyStar should be *", FinishKeyStar, "*"},
+		{"FinishKeyPound should be #", FinishKeyPound, "#"},
+		{"FinishKeyNone should be empty-string", FinishKeyNone, ""},
+	}
+
+	for _, test := range tests {
+		if out := test.in.String(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestFinishOnKey_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "finishOnKey"}
+
+	tests := []struct {
+		desc     string
+		in       FinishOnKey
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Vault) voice should be Alice", FinishOnKey(0), attrName, attrName, ""},
+		{"FinishKeyNumber0 should be 0", FinishKeyNumber0, attrName, attrName, "0"},
+		{"FinishKeyNumber9 should be 9", FinishKeyNumber9, attrName, attrName, "9"},
+		{"FinishKeyStar should be *", FinishKeyStar, attrName, attrName, "*"},
+		{"FinishKeyPound should be #", FinishKeyPound, attrName, attrName, "#"},
+		{"FinishKeyNone should be empty-string", FinishKeyNone, attrName, attrName, ""},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}

--- a/twiml/gather_input.go
+++ b/twiml/gather_input.go
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import "encoding/xml"
+
+// GatherInput allows you to define the type of input to gather from a caller.
+// The constant values can be bitwise-OR'ed together to support `dtmf speech`
+// input mode.
+type GatherInput uint8
+
+const (
+	// GatherInputDTMF captures user in the form of dual tone multi frequency
+	// inputs. This is the user pressing numbers on the keypad.
+	GatherInputDTMF GatherInput = 1 << iota
+
+	// GatherInputSpeech enables capturing user input in the form of speech.
+	GatherInputSpeech
+)
+
+// GatherInputDTMFSpeech is a bitwise-OR of GatherInputDTMF and
+// GatherInputSpeech as a convenience.
+const GatherInputDTMFSpeech = GatherInputDTMF | GatherInputSpeech
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (g GatherInput) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: g.String(),
+	}
+
+	return attr, nil
+}
+
+func (g GatherInput) String() string {
+	switch {
+	case g == GatherInputDTMFSpeech:
+		return "dtmf speech"
+	case g&GatherInputDTMF == GatherInputDTMF:
+		return "dtmf"
+	case g&GatherInputSpeech == GatherInputSpeech:
+		return "speech"
+	default:
+		return ""
+	}
+}

--- a/twiml/gather_input_test.go
+++ b/twiml/gather_input_test.go
@@ -1,0 +1,81 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestGatherInput_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   GatherInput
+		out  string
+	}{
+		{"Default (Zero Value) GatherInput should return empty-string", GatherInput(0), ""},
+		{"GatherInputDTMF should enable DTMF input gathering", GatherInputDTMF, "dtmf"},
+		{"GatherInputSpeech should enable speech input gathering", GatherInputSpeech, "speech"},
+		{"GatherInputDTMF | GatherInputSpeech should enable speech input gathering", GatherInputDTMF | GatherInputSpeech, "dtmf speech"},
+		{"GatherInputDTMFSpeech should enable speech input gathering", GatherInputDTMFSpeech, "dtmf speech"},
+	}
+
+	for _, test := range tests {
+		if out := test.in.String(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestGatherInput_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "trim"}
+
+	tests := []struct {
+		desc     string
+		in       GatherInput
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Value) GatherInput should return empty-string", GatherInput(0), attrName, attrName, ""},
+		{"GatherInputDTMF should enable DTMF input gathering", GatherInputDTMF, attrName, attrName, "dtmf"},
+		{"GatherInputSpeech should enable speech input gathering", GatherInputSpeech, attrName, attrName, "speech"},
+		{"GatherInputDTMF | GatherInputSpeech should enable speech input gathering", GatherInputDTMF | GatherInputSpeech, attrName, attrName, "dtmf speech"},
+		{"GatherInputDTMFSpeech should enable speech input gathering", GatherInputDTMFSpeech, attrName, attrName, "dtmf speech"},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}

--- a/twiml/language.go
+++ b/twiml/language.go
@@ -1,0 +1,166 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import "encoding/xml"
+
+// Language represents a language as understood by the TwiML. The language
+// selected depends on the voice used to speak. By default this package uses the
+// alice voice, as it allows more language support. If you wish to use the "man"
+// or "woman" voice, you'll need to use one of the legacy languages.
+type Language uint16
+
+const (
+	//LangDefault is the default value for language and causes the field to not be set.
+	LangDefault Language = iota
+
+	// LangEnglishUS is the English language as spoken in the United States.
+	LangEnglishUS
+
+	// LangCatalanSpain is the Catalan language as spoken in Spain.
+	LangCatalanSpain
+
+	// LangChineseCantonese is the Chinese (Cantonese) language.
+	LangChineseCantonese
+
+	// LangChineseMandarin is the Chinese (Mandarin) language.
+	LangChineseMandarin
+
+	// LangChineseTaiwaneseMandarin is the Chinese (Taiwanese Mandarin) language.
+	LangChineseTaiwaneseMandarin
+
+	// LangDanishDenmark is the Danish language as spoken in Denmark.
+	LangDanishDenmark
+
+	// LangDutchNetherlands is the Dutch language as spoken in the Netherlands.
+	LangDutchNetherlands
+
+	// LangEnglishAustralia is the English language as spoken in Australia.
+	LangEnglishAustralia
+
+	// LangEnglishCanada is what you think it is, bud. English as spoken in Canada.
+	// No surprise there, eh?
+	LangEnglishCanada
+
+	// LangEnglishUK is the English language as spoken in the United Kingdom.
+	LangEnglishUK
+
+	// LangFinnishFinland is the Finnish language as spoken in Finland.
+	LangFinnishFinland
+
+	// LangFrenchCanada is the French language as spoken in Canada.
+	LangFrenchCanada
+
+	// LangFrenchFrance is the French language as spoken in France.
+	LangFrenchFrance
+
+	// LangGermanGermany is the German language as spoken in Germany.
+	LangGermanGermany
+
+	// LangItalianItaly is the Italian language as spoken in Italy.
+	LangItalianItaly
+
+	// LangJapaneseJapan is the Japanese language as spoken in Japan.
+	// ありがとうございます
+	LangJapaneseJapan
+
+	// LangKoreanKorea is the Korean language as spoken in Korea.
+	LangKoreanKorea
+
+	// LangNorwegianNorway is the Norwegian language as spoken in Norway.
+	LangNorwegianNorway
+
+	// LangPolishPoland is the Polish language as spoken in Poland.
+	LangPolishPoland
+
+	// LangPortugeseBrazil is the Portugese language as spoken in Brazil.
+	LangPortugeseBrazil
+
+	// LangPortugesePortugal is the Portugese language as spoken on Portugal
+	LangPortugesePortugal
+
+	// LangRussianRussia is the Russian language as spoken in Russia.
+	LangRussianRussia
+
+	// LangSpanishMexico is the Spanish language as spoken in Mexico.
+	LangSpanishMexico
+
+	// LangSpanishSpain is the Spanish language as spoken in Spain.
+	LangSpanishSpain
+
+	// LangSwedishSweden is the Swedish language as spoken in Sweden.
+	LangSwedishSweden
+)
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (l Language) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: l.String(),
+	}
+
+	return attr, nil
+}
+
+func (l Language) String() string {
+	switch l {
+	case LangDefault:
+		return ""
+	case LangEnglishUS:
+		return "en-US"
+	case LangCatalanSpain:
+		return "ca-ES"
+	case LangChineseCantonese:
+		return "zh-HK"
+	case LangChineseMandarin:
+		return "zh-CN"
+	case LangChineseTaiwaneseMandarin:
+		return "zh-TW"
+	case LangDanishDenmark:
+		return "da-DK"
+	case LangDutchNetherlands:
+		return "nl-NL"
+	case LangEnglishAustralia:
+		return "en-AU"
+	case LangEnglishCanada:
+		return "en-CA"
+	case LangEnglishUK:
+		return "en-GB"
+	case LangFinnishFinland:
+		return "fi-FI"
+	case LangFrenchCanada:
+		return "fr-CA"
+	case LangFrenchFrance:
+		return "fr-FR"
+	case LangGermanGermany:
+		return "de-DE"
+	case LangItalianItaly:
+		return "it-IT"
+	case LangJapaneseJapan:
+		return "ja-JP"
+	case LangKoreanKorea:
+		return "ko-KR"
+	case LangNorwegianNorway:
+		return "nb-NO"
+	case LangPolishPoland:
+		return "pl-PL"
+	case LangPortugeseBrazil:
+		return "pt-BR"
+	case LangPortugesePortugal:
+		return "pt-PT"
+	case LangRussianRussia:
+		return "ru-RU"
+	case LangSpanishMexico:
+		return "es-MX"
+	case LangSpanishSpain:
+		return "es-ES"
+	case LangSwedishSweden:
+		return "sv-SE"
+	default:
+		return "unknown"
+	}
+}

--- a/twiml/language_test.go
+++ b/twiml/language_test.go
@@ -1,0 +1,143 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestLanguage_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   Language
+		out  string
+	}{
+		{"Default (Zero Value) should be empty string", Language(0), ""},
+		{"LangDefault should be empty string", LangDefault, ""},
+		{"DanishDenmark should be Danish, Denmark", LangDanishDenmark, "da-DK"},
+		{"GermanGermany should be German, Germany", LangGermanGermany, "de-DE"},
+		{"EnglishAustralia should be English, Australia", LangEnglishAustralia, "en-AU"},
+		{"EnglishCanada should be English, Canada", LangEnglishCanada, "en-CA"},
+		{"EnglishUK should be English, United Kingdom", LangEnglishUK, "en-GB"},
+		{"EnglishUS should be English, United States", LangEnglishUS, "en-US"},
+		{"CatalanSpain should be Catalan, Spain", LangCatalanSpain, "ca-ES"},
+		{"SpanishSpain should be Spanish, Spain", LangSpanishSpain, "es-ES"},
+		{"SpanishMexico should be Spanish, Mexico", LangSpanishMexico, "es-MX"},
+		{"FinnishFinland should be Finnish, Finland", LangFinnishFinland, "fi-FI"},
+		{"FrenchCanada should be French, Canada", LangFrenchCanada, "fr-CA"},
+		{"FrenchFrance should be French, France", LangFrenchFrance, "fr-FR"},
+		{"ItalianItaly should be Italian, Italy", LangItalianItaly, "it-IT"},
+		{"JapaneseJapan should be Japanese, Japan", LangJapaneseJapan, "ja-JP"},
+		{"KoreaKorean should be Korea, Korean", LangKoreanKorea, "ko-KR"},
+		{"NorwegianNorway should be Norwegian, Norway", LangNorwegianNorway, "nb-NO"},
+		{"DutchNetherlands should be Dutch, Netherlands", LangDutchNetherlands, "nl-NL"},
+		{"PolishPoland should be Polish, Poland", LangPolishPoland, "pl-PL"},
+		{"PortugeseBrazil should be Portugese, Brazil", LangPortugeseBrazil, "pt-BR"},
+		{"PortugesePortugal should be Portugese, Portugal", LangPortugesePortugal, "pt-PT"},
+		{"RussianRussia should be Russia, Russian", LangRussianRussia, "ru-RU"},
+		{"SwedishSweden should be Swedish, Sweden", LangSwedishSweden, "sv-SE"},
+		{"ChineseMandarin should be Chinese (Mandarin)", LangChineseMandarin, "zh-CN"},
+		{"ChineseCantonese should be Chinese (Cantonese)", LangChineseCantonese, "zh-HK"},
+		{"ChineseTaiwaneseMandarin should be Chinese (Taiwanese Mandarin)", LangChineseTaiwaneseMandarin, "zh-TW"},
+	}
+
+	var out string
+
+	for _, test := range tests {
+		out = test.in.String()
+
+		if out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nLanguage(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestLanguage_MarshalXMLAttr(t *testing.T) {
+	langName := xml.Name{Local: "language"}
+
+	tests := []struct {
+		desc     string
+		in       Language
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Value) should be empty string", Language(0), langName, langName, ""},
+		{"EnglishUS should be English, United States", LangEnglishUS, langName, langName, "en-US"},
+		{"SpanishMexico should be Spanish, Mexico", LangSpanishMexico, langName, langName, "es-MX"},
+		{"JapaneseJapan should be Japanese, Japan", LangJapaneseJapan, langName, langName, "ja-JP"},
+		{"KoreaKorean should be Korea, Korean", LangKoreanKorea, langName, langName, "ko-KR"},
+		{"NorwegianNorway should be Norwegian, Norway", LangNorwegianNorway, langName, langName, "nb-NO"},
+		{"DutchNetherlands should be Dutch, Netherlands", LangDutchNetherlands, langName, langName, "nl-NL"},
+		{
+			"ChineseCantonese should be Chinese (Cantonese)",
+			LangChineseCantonese,
+			xml.Name{Space: "blah", Local: "Test"},
+			xml.Name{Space: "blah", Local: "Test"},
+			"zh-HK",
+		},
+	}
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nLanguage(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nLanguage(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nLanguage(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}
+
+func BenchmarkLanguageStringEnglishUS(b *testing.B) {
+	lang := LangEnglishUS
+	for i := 0; i < b.N; i++ {
+		lang.String()
+	}
+}
+
+func BenchmarkLanguageStringJapaneseJapan(b *testing.B) {
+	lang := LangJapaneseJapan
+	for i := 0; i < b.N; i++ {
+		lang.String()
+	}
+}
+
+func BenchmarkLanguageStringSwedishSweden(b *testing.B) {
+	lang := LangSwedishSweden
+	for i := 0; i < b.N; i++ {
+		lang.String()
+	}
+}
+
+func BenchmarkLanguageStringUnknown(b *testing.B) {
+	lang := Language(100)
+	for i := 0; i < b.N; i++ {
+		lang.String()
+	}
+}

--- a/twiml/reject_reason.go
+++ b/twiml/reject_reason.go
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import "encoding/xml"
+
+// RejectReason specifies the rejection reason for a rejected call.
+type RejectReason uint8
+
+const (
+	// RejectReasonRejected is the rejection reason indicating the call was
+	// rejected.
+	RejectReasonRejected RejectReason = 1 << iota
+
+	// RejectReasonBusy is the rejection reason indicating the call was busy.
+	RejectReasonBusy
+)
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (r RejectReason) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: r.String(),
+	}
+
+	return attr, nil
+}
+
+func (r RejectReason) String() string {
+	switch r {
+	case RejectReasonRejected:
+		return "rejected"
+	case RejectReasonBusy:
+		return "busy"
+	default:
+		return ""
+	}
+}

--- a/twiml/reject_reason_test.go
+++ b/twiml/reject_reason_test.go
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestRejectReason_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   RejectReason
+		out  string
+	}{
+		{"Default (Zero Value) RejectReason should be nothing", RejectReason(0), ""},
+		{"RejectReasonRejected should set the rejection as rejected", RejectReasonRejected, "rejected"},
+		{"RejectReasonBusy should set the rejection as busy", RejectReasonBusy, "busy"},
+	}
+
+	for _, test := range tests {
+		if out := test.in.String(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestRejectReason_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "trim"}
+
+	tests := []struct {
+		desc     string
+		in       RejectReason
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Value) RejectReason should be nothing", RejectReason(0), attrName, attrName, ""},
+		{"RejectReasonRejected should set the rejection as rejected", RejectReasonRejected, attrName, attrName, "rejected"},
+		{"RejectReasonBusy should set the rejection as busy", RejectReasonBusy, attrName, attrName, "busy"},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}

--- a/twiml/ring_tone.go
+++ b/twiml/ring_tone.go
@@ -1,0 +1,239 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import "encoding/xml"
+
+// RingTone lets you record both legs of a call within the associated Dial verb. Recordings are available in two options: mono-channel or dual-channel.
+type RingTone uint8
+
+const (
+	// RingToneAutomatic is omitted from being rendered to XML, which
+	// effectively tells Twilio to use the default value.
+	RingToneAutomatic RingTone = iota
+
+	// RingToneAustralia is the ringback tone from Australia (au).
+	RingToneAustralia
+
+	// RingToneAustria is the ringback tone from Austria (at).
+	RingToneAustria
+
+	// RingToneBelgium is the ringback tone from Belgium (be).
+	RingToneBelgium
+
+	// RingToneBulgaria is the ringback tone from Bulgaria (bg).
+	RingToneBulgaria
+
+	// RingToneBrazil is the ringback tone from Brazil (br).
+	RingToneBrazil
+
+	// RingToneChile is the ringback tone from Chile (cl).
+	RingToneChile
+
+	// RingToneChina is the ringback tone from China (cn).
+	RingToneChina
+
+	// RingToneCzechia is the ringback tone from Czechia (cz).
+	RingToneCzechia
+
+	// RingToneDenmark is the ringback tone from Denmark (dk).
+	RingToneDenmark
+
+	// RingToneEstonia is the ringback tone from Estonia (ee).
+	RingToneEstonia
+
+	// RingToneFinland is the ringback tone from Finland (fi).
+	RingToneFinland
+
+	// RingToneFrance is the ringback tone from France (fr).
+	RingToneFrance
+
+	// RingToneGreece is the ringback tone from Greece (gr).
+	RingToneGreece
+
+	// RingToneGermany is the ringback tone from Germany (de).
+	RingToneGermany
+
+	// RingToneHungary is the ringback tone from Hungary (hu).
+	RingToneHungary
+
+	// RingToneIsrael is the ringback tone from Israel (il).
+	RingToneIsrael
+
+	// RingToneIndia is the ringback tone from India (in).
+	RingToneIndia
+
+	// RingToneItaly is the ringback tone from Italy (it).
+	RingToneItaly
+
+	// RingToneLithuania is the ringback tone from Lithuania (lt).
+	RingToneLithuania
+
+	// RingToneJapan is the ringback tone from Japan (jp).
+	RingToneJapan
+
+	// RingToneMexico is the ringback tone from Mexico (mx).
+	RingToneMexico
+
+	// RingToneMalaysia is the ringback tone from Malaysia (my).
+	RingToneMalaysia
+
+	// RingToneNetherlands is the ringback tone from the Netherlands (nl).
+	RingToneNetherlands
+
+	// RingToneNorway is the ringback tone from Norway (no).
+	RingToneNorway
+
+	// RingToneNewZealand is the ringback tone from New Zealand (nz).
+	RingToneNewZealand
+
+	// RingTonePhilippines is the ringback tone from Philippines (ph).
+	RingTonePhilippines
+
+	// RingTonePoland is the ringback tone from Poland (pl).
+	RingTonePoland
+
+	// RingTonePortugal is the ringback tone from Portugal (pt).
+	RingTonePortugal
+
+	// RingToneRussia is the ringback tone from Russia (ru).
+	RingToneRussia
+
+	// RingToneSingapore is the ringback tone from Singapore (sg).
+	RingToneSingapore
+
+	// RingToneSpain is the ringback tone from Spain (es).
+	RingToneSpain
+
+	// RingToneSweden is the ringback tone from Sweden (se).
+	RingToneSweden
+
+	// RingToneSwitzerland is the ringback tone from Switzerland (ch).
+	RingToneSwitzerland
+
+	// RingToneTaiwan is the ringback tone from Taiwan (tw).
+	RingToneTaiwan
+
+	// RingToneThailand is the ringback tone from Thailand (th).
+	RingToneThailand
+
+	// RingToneUK is the ringback tone from the United Kingdom (uk).
+	RingToneUK
+
+	// RingToneUS is the ringback tone from the United States (us).
+	RingToneUS
+
+	// RingToneUSOld is the old ringback tone from the United States (us-old).
+	// The API documentation does not clarify what the difference is between
+	// RingToneUSOld and RingToneUS.
+	RingToneUSOld
+
+	// RingToneVenezuela is the ringback tone from Venezuela (ve).
+	RingToneVenezuela
+
+	// RingToneSouthAfrica is the ringback tone from South Africa (za).
+	RingToneSouthAfrica
+)
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (r RingTone) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: r.String(),
+	}
+
+	return attr, nil
+}
+
+func (r RingTone) String() string {
+	switch r {
+	case RingToneAustralia:
+		return "au"
+	case RingToneAustria:
+		return "at"
+	case RingToneBelgium:
+		return "be"
+	case RingToneBulgaria:
+		return "bg"
+	case RingToneBrazil:
+		return "br"
+	case RingToneChile:
+		return "cl"
+	case RingToneChina:
+		return "cn"
+	case RingToneCzechia:
+		return "cz"
+	case RingToneDenmark:
+		return "dk"
+	case RingToneEstonia:
+		return "ee"
+	case RingToneFinland:
+		return "fi"
+	case RingToneFrance:
+		return "fr"
+	case RingToneGreece:
+		return "gr"
+	case RingToneGermany:
+		return "de"
+	case RingToneHungary:
+		return "hu"
+	case RingToneIsrael:
+		return "il"
+	case RingToneIndia:
+		return "in"
+	case RingToneItaly:
+		return "it"
+	case RingToneJapan:
+		return "jp"
+	case RingToneLithuania:
+		return "lt"
+	case RingToneMexico:
+		return "mx"
+	case RingToneMalaysia:
+		return "my"
+	case RingToneNetherlands:
+		return "nl"
+	case RingToneNorway:
+		return "no"
+	case RingToneNewZealand:
+		return "nz"
+	case RingTonePhilippines:
+		return "ph"
+	case RingTonePoland:
+		return "pl"
+	case RingTonePortugal:
+		return "pt"
+	case RingToneRussia:
+		return "ru"
+	case RingToneSingapore:
+		return "sg"
+	case RingToneSpain:
+		return "es"
+	case RingToneSweden:
+		return "se"
+	case RingToneSwitzerland:
+		return "ch"
+	case RingToneTaiwan:
+		return "tw"
+	case RingToneThailand:
+		return "th"
+	case RingToneUK:
+		return "uk"
+	case RingToneUS:
+		return "us"
+	case RingToneUSOld:
+		return "us-old"
+	case RingToneVenezuela:
+		return "ve"
+	case RingToneSouthAfrica:
+		return "za"
+	case RingToneAutomatic:
+		return "automatic"
+	default:
+		return ""
+	}
+}

--- a/twiml/ring_tone_test.go
+++ b/twiml/ring_tone_test.go
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestRingTone_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   RingTone
+		out  string
+	}{
+		{"Default (Zero Value) RingTone should return automatic", RingTone(0), "automatic"},
+		{"RingToneAutomatic should return automatic", RingToneAutomatic, "automatic"},
+		{"RingToneAustralia should return au", RingToneAustralia, "au"},
+		{"RingToneAustria should return at", RingToneAustria, "at"},
+		{"RingToneBelgium should return be", RingToneBelgium, "be"},
+		{"RingToneBulgaria should return bg", RingToneBulgaria, "bg"},
+		{"RingToneBrazil should return br", RingToneBrazil, "br"},
+		{"RingToneChile should return cl", RingToneChile, "cl"},
+		{"RingToneChina should return cn", RingToneChina, "cn"},
+		{"RingToneCzechia should return cz", RingToneCzechia, "cz"},
+		{"RingToneDenmark should return dk", RingToneDenmark, "dk"},
+		{"RingToneEstonia should return ee", RingToneEstonia, "ee"},
+		{"RingToneFinland should return fi", RingToneFinland, "fi"},
+		{"RingToneFrance should return fr", RingToneFrance, "fr"},
+		{"RingToneGreece should return gr", RingToneGreece, "gr"},
+		{"RingToneGermany should return de", RingToneGermany, "de"},
+		{"RingToneHungary should return hu", RingToneHungary, "hu"},
+		{"RingToneIsrael should return il", RingToneIsrael, "il"},
+		{"RingToneIndia should return in", RingToneIndia, "in"},
+		{"RingToneItaly should return it", RingToneItaly, "it"},
+		{"RingToneLithuania should return lt", RingToneLithuania, "lt"},
+		{"RingToneJapan should return jp", RingToneJapan, "jp"},
+		{"RingToneMexico should return mx", RingToneMexico, "mx"},
+		{"RingToneMalaysia should return my", RingToneMalaysia, "my"},
+		{"RingToneNetherlands should return nl", RingToneNetherlands, "nl"},
+		{"RingToneNorway should return no", RingToneNorway, "no"},
+		{"RingToneNewZealand should return nz", RingToneNewZealand, "nz"},
+		{"RingTonePhilippines should return ph", RingTonePhilippines, "ph"},
+		{"RingTonePoland should return pl", RingTonePoland, "pl"},
+		{"RingTonePortugal should return pt", RingTonePortugal, "pt"},
+		{"RingToneRussia should return ru", RingToneRussia, "ru"},
+		{"RingToneSingapore should return sg", RingToneSingapore, "sg"},
+		{"RingToneSpain should return es", RingToneSpain, "es"},
+		{"RingToneSweden should return se", RingToneSweden, "se"},
+		{"RingToneSwitzerland should return ch", RingToneSwitzerland, "ch"},
+		{"RingToneTaiwan should return tw", RingToneTaiwan, "tw"},
+		{"RingToneThailand should return th", RingToneThailand, "th"},
+		{"RingToneUK should return uk", RingToneUK, "uk"},
+		{"RingToneUS should return us", RingToneUS, "us"},
+		{"RingToneUSOld should return us-old", RingToneUSOld, "us-old"},
+		{"RingToneVenezuela should return ve", RingToneVenezuela, "ve"},
+		{"RingToneSouthAfrica should return za", RingToneSouthAfrica, "za"},
+	}
+
+	for _, test := range tests {
+		if out := test.in.String(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestRingTone_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "trim"}
+
+	tests := []struct {
+		desc     string
+		in       RingTone
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Value) RingTone should return automatic", RingTone(0), attrName, attrName, "automatic"},
+		{"RingToneJapan should return jp", RingToneJapan, attrName, attrName, "jp"},
+		{"RingToneUS should return us", RingToneUS, attrName, attrName, "us"},
+		{"RingToneUSOld should return us-old", RingToneUSOld, attrName, attrName, "us-old"},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}

--- a/twiml/status_callback_event.go
+++ b/twiml/status_callback_event.go
@@ -1,0 +1,87 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"bytes"
+	"encoding/xml"
+)
+
+// StatusCallbackEvent allows you to specify which events Twilio should webhook
+// on. If you'd like to have the callback fire for multiple event types, you can
+// use a bitwise-OR to select multiple event types.
+type StatusCallbackEvent uint8
+
+const (
+	// StatusCallbackInitiated is the event for when a call is started, before
+	// it starts to ring.
+	StatusCallbackInitiated StatusCallbackEvent = 1 << iota
+
+	// StatusCallbackRinging is the event for when a call starts to ring.
+	StatusCallbackRinging
+
+	// StatusCallbackAnswered is the event for when the call is answered.
+	StatusCallbackAnswered
+
+	// StatusCallbackCompleted is the event for when the call is finished.
+	StatusCallbackCompleted
+)
+
+// StatusCallbackAll is a combination of all StatusCallbackEvents, for endpoints
+// that want to receive a webhook from Twilio for all call status events.
+const StatusCallbackAll = StatusCallbackInitiated | StatusCallbackRinging | StatusCallbackAnswered | StatusCallbackCompleted
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (s StatusCallbackEvent) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: s.String(),
+	}
+
+	return attr, nil
+}
+
+func (s StatusCallbackEvent) String() string {
+	if s == StatusCallbackEvent(0) {
+		return ""
+	}
+
+	buf := bufferPool.Get().(*bytes.Buffer)
+
+	defer bufferPool.Put(buf)
+	defer buf.Reset()
+
+	if s&StatusCallbackInitiated == StatusCallbackInitiated {
+		if buf.Len() > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString("initiated")
+	}
+
+	if s&StatusCallbackRinging == StatusCallbackRinging {
+		if buf.Len() > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString("ringing")
+	}
+
+	if s&StatusCallbackAnswered == StatusCallbackAnswered {
+		if buf.Len() > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString("answered")
+	}
+
+	if s&StatusCallbackCompleted == StatusCallbackCompleted {
+		if buf.Len() > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString("completed")
+	}
+
+	return buf.String()
+}

--- a/twiml/status_callback_event_test.go
+++ b/twiml/status_callback_event_test.go
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestStatusCallbackEvent_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   StatusCallbackEvent
+		out  string
+	}{
+		{"Default (Zero Value) StatusCallbackEvent should return empty-string", StatusCallbackEvent(0), ""},
+		{"StatusCallbackInitiated should return initiated", StatusCallbackInitiated, "initiated"},
+		{"StatusCallbackRinging should return ringing", StatusCallbackRinging, "ringing"},
+		{"StatusCallbackAnswered should return answered", StatusCallbackAnswered, "answered"},
+		{"StatusCallbackCompleted should return completed", StatusCallbackCompleted, "completed"},
+		{`StatusCallbackRinging|StatusCallbackCompleted should return "ringing completed"`, StatusCallbackRinging | StatusCallbackCompleted, "ringing completed"},
+		{"StatusCallbackAll should return all statuses", StatusCallbackAll, "initiated ringing answered completed"},
+	}
+
+	for _, test := range tests {
+		if out := test.in.String(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestStatusCallbackEvent_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "trim"}
+
+	tests := []struct {
+		desc     string
+		in       StatusCallbackEvent
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Value) StatusCallbackEvent should return empty-string", StatusCallbackEvent(0), attrName, attrName, ""},
+		{"StatusCallbackInitiated should return initiated", StatusCallbackInitiated, attrName, attrName, "initiated"},
+		{"StatusCallbackRinging should return ringing", StatusCallbackRinging, attrName, attrName, "ringing"},
+		{"StatusCallbackAnswered should return answered", StatusCallbackAnswered, attrName, attrName, "answered"},
+		{"StatusCallbackCompleted should return completed", StatusCallbackCompleted, attrName, attrName, "completed"},
+		{`StatusCallbackRinging|StatusCallbackCompleted should return "ringing completed"`, StatusCallbackRinging | StatusCallbackCompleted, attrName, attrName, "ringing completed"},
+		{"StatusCallbackAll should return all statuses", StatusCallbackAll, attrName, attrName, "initiated ringing answered completed"},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}

--- a/twiml/testdata/full.xml
+++ b/twiml/testdata/full.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Say language="en-US" loop="2" voice="alice">Testing!</Say>
+  <Record action="https://example.org/action" method="POST" timeout="3" finishOnKey="1234567890*#" maxLength="350" playBeep="true" trim="trim-silence" recordingStatusCallback="https://example.org/rsc" recordingStatusCallbackMethod="POST" transcribe="true" transcribeCallback="https://example.org/tc"></Record>
+  <Reject reason="rejected"></Reject>
+  <Hangup></Hangup>
+  <Play loop="2" digits="0w42*">https://example.org/audio.mp3</Play>
+  <Pause length="4"></Pause>
+  <Sms to="+14155555555" from="+14155555656" action="https://example.org/action" method="POST" statusCallback="https://example.org/scb">Test message!</Sms>
+  <Redirect method="POST">https://example.org/redirect</Redirect>
+  <Leave></Leave>
+  <Enqueue action="https://example.org/action" method="POST" waitUrl="https://example.org/wait" waitUrlMethod="GET" workflowSid="WWtesting">test</Enqueue>
+  <Gather input="dtmf speech" action="https://example.org/action" method="POST" timeout="5" finishOnKey="*#" numDigits="42" partialResultCallback="https://example.org/prc" partialResultCallbackMethod="POST" language="en-US" hints="bacon ipsum, other stuff" bargeIn="false"></Gather>
+  <Dial action="https://example.org/action" method="POST" timeout="5" hangupOnStar="true" timeLimit="10" callerId="+14155555555" record="record-from-ringing-dual" trim="trim-silence" recordingStatusCallback="https://example.org/rsc" recordingStatusCallbackMethod="POST" answerOnBridge="true" ringTone="us-old">415-555-5555</Dial>
+  <Say language="en-AU" loop="3" voice="alice">Goodbye!</Say>
+</Response>

--- a/twiml/testdata/fullDialClient.xml
+++ b/twiml/testdata/fullDialClient.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial hangupOnStar="false" answerOnBridge="false">
+    <Client url="https://example.org/url" method="POST" statusCallbackEvent="initiated ringing answered completed" statusCallback="https://example.org/scb" statusCallbackMethod="POST">Testing</Client>
+  </Dial>
+</Response>

--- a/twiml/testdata/fullDialConference.xml
+++ b/twiml/testdata/fullDialConference.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial hangupOnStar="false" answerOnBridge="false">
+    <Conference muted="true" beep="true" startConferenceOnEnter="true" endConferenceOnExit="true" waitUrl="https://example.org/wait" waitMethod="POST" maxParticipants="42" record="record-from-start" region="jp1" trim="trim-silence" whisper="testWhisper" statusCallbackEvent="start end join leave mute hold speaker" statusCallbackMethod="POST" recordingStatusCallback="https://example.org/rsc" recordingStatusCallbackMethod="POST">testConf</Conference>
+  </Dial>
+</Response>

--- a/twiml/testdata/fullDialNumber.xml
+++ b/twiml/testdata/fullDialNumber.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial hangupOnStar="false" answerOnBridge="false">
+    <Number sendDigits="ww42" url="https://example.org/url" method="POST" statusCallbackEvent="initiated ringing answered completed" statusCallback="https://example.org/scb" statusCallbackMethod="POST">+14155555555</Number>
+  </Dial>
+</Response>

--- a/twiml/testdata/fullDialQueue.xml
+++ b/twiml/testdata/fullDialQueue.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial hangupOnStar="false" answerOnBridge="false">
+    <Queue url="https://example.org/url" method="POST" reservationSid="reservationSid" postWorkActivitySid="postWorkActivitySid">Testing</Queue>
+  </Dial>
+</Response>

--- a/twiml/testdata/fullDialSIM.xml
+++ b/twiml/testdata/fullDialSIM.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial hangupOnStar="false" answerOnBridge="false">
+    <Sim>Testing</Sim>
+  </Dial>
+</Response>

--- a/twiml/testdata/fullDialSIP.xml
+++ b/twiml/testdata/fullDialSIP.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial hangupOnStar="false" answerOnBridge="false">
+    <Sip username="testUser" password="testPass" url="https://example.org/url" method="POST" statusCallbackEvent="initiated ringing answered completed" statusCallback="https://example.org/scb" statusCallbackMethod="POST" timeout="42" hangupOnStar="true" timeLimit="84" callerId="theckman" record="record-from-ringing-dual" trim="trim-silence" recordingStatusCallback="https://example.org/rscb" recordingStatusCallbackMethod="POST" answerOnBridge="true" ringTone="jp">Testing</Sip>
+  </Dial>
+</Response>

--- a/twiml/testdata/fullDialWithNouns.xml
+++ b/twiml/testdata/fullDialWithNouns.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial hangupOnStar="false" answerOnBridge="false">
+    <Sip username="testUser" password="testPass" url="https://example.org/url" method="POST" statusCallbackEvent="initiated ringing answered completed" statusCallback="https://example.org/scb" statusCallbackMethod="POST" timeout="42" hangupOnStar="true" timeLimit="84" callerId="theckman" record="record-from-ringing-dual" trim="trim-silence" recordingStatusCallback="https://example.org/rscb" recordingStatusCallbackMethod="POST" answerOnBridge="true" ringTone="jp">Testing</Sip>
+    <Queue url="https://example.org/url" method="POST" reservationSid="reservationSid" postWorkActivitySid="postWorkActivitySid">Testing</Queue>
+  </Dial>
+</Response>

--- a/twiml/testdata/fulldial.xml
+++ b/twiml/testdata/fulldial.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial action="https://example.org/action" method="POST" timeout="5" hangupOnStar="true" timeLimit="10" callerId="+14155555555" record="record-from-ringing-dual" trim="trim-silence" recordingStatusCallback="https://example.org/rsc" recordingStatusCallbackMethod="POST" answerOnBridge="true" ringTone="us-old">415-555-5555</Dial>
+</Response>

--- a/twiml/testdata/fullenqueue.xml
+++ b/twiml/testdata/fullenqueue.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Enqueue action="https://example.org/action" method="POST" waitUrl="https://example.org/wait" waitUrlMethod="GET" workflowSid="WWtesting">test</Enqueue>
+</Response>

--- a/twiml/testdata/fullenqueuewithtask.xml
+++ b/twiml/testdata/fullenqueuewithtask.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Enqueue action="https://example.org/action" method="POST" waitUrl="https://example.org/wait" waitUrlMethod="GET" workflowSid="WWtesting">test
+    <Task>{&#34;test&#34;:&#34;obj&#34;}</Task>
+  </Enqueue>
+</Response>

--- a/twiml/testdata/fullgather.xml
+++ b/twiml/testdata/fullgather.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Gather input="dtmf speech" action="https://example.org/action" method="POST" timeout="5" finishOnKey="*#" numDigits="42" partialResultCallback="https://example.org/prc" partialResultCallbackMethod="POST" language="en-US" hints="bacon ipsum, other stuff" bargeIn="false"></Gather>
+</Response>

--- a/twiml/testdata/fullgatherwithverbs.xml
+++ b/twiml/testdata/fullgatherwithverbs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Gather input="dtmf speech" action="https://example.org/action" method="POST" timeout="5" finishOnKey="*#" numDigits="42" partialResultCallback="https://example.org/prc" partialResultCallbackMethod="POST" language="en-US" hints="bacon ipsum, other stuff" bargeIn="false">
+    <Say language="en-US" loop="2" voice="alice">Testing!</Say>
+    <Play loop="2" digits="0w42*">https://example.org/audio.mp3</Play>
+    <Pause length="4"></Pause>
+  </Gather>
+</Response>

--- a/twiml/testdata/fullhangup.xml
+++ b/twiml/testdata/fullhangup.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Hangup></Hangup>
+</Response>

--- a/twiml/testdata/fullleave.xml
+++ b/twiml/testdata/fullleave.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Leave></Leave>
+</Response>

--- a/twiml/testdata/fullpause.xml
+++ b/twiml/testdata/fullpause.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Pause length="4"></Pause>
+</Response>

--- a/twiml/testdata/fullplay.xml
+++ b/twiml/testdata/fullplay.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Play loop="2" digits="0w42*">https://example.org/audio.mp3</Play>
+</Response>

--- a/twiml/testdata/fullrecord.xml
+++ b/twiml/testdata/fullrecord.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Record action="https://example.org/action" method="POST" timeout="3" finishOnKey="1234567890*#" maxLength="350" playBeep="true" trim="trim-silence" recordingStatusCallback="https://example.org/rsc" recordingStatusCallbackMethod="POST" transcribe="true" transcribeCallback="https://example.org/tc"></Record>
+</Response>

--- a/twiml/testdata/fullredirect.xml
+++ b/twiml/testdata/fullredirect.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Redirect method="POST">https://example.org/redirect</Redirect>
+</Response>

--- a/twiml/testdata/fullreject.xml
+++ b/twiml/testdata/fullreject.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Reject reason="rejected"></Reject>
+</Response>

--- a/twiml/testdata/fullsay.xml
+++ b/twiml/testdata/fullsay.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Say language="en-US" loop="2" voice="alice">Testing!</Say>
+</Response>

--- a/twiml/testdata/fullsms.xml
+++ b/twiml/testdata/fullsms.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Sms to="+14155555555" from="+14155555656" action="https://example.org/action" method="POST" statusCallback="https://example.org/scb">Test message!</Sms>
+</Response>

--- a/twiml/testdata/simple.xml
+++ b/twiml/testdata/simple.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Say>Testing!</Say>
+  <Record transcribe="false"></Record>
+  <Reject></Reject>
+  <Hangup></Hangup>
+  <Play>https://example.org/audio.mp3</Play>
+  <Pause></Pause>
+  <Sms>Test message!</Sms>
+  <Redirect>https://example.org/redirect</Redirect>
+  <Leave></Leave>
+  <Enqueue>test</Enqueue>
+  <Gather></Gather>
+  <Dial hangupOnStar="false" answerOnBridge="false">415-555-5555</Dial>
+  <Say>Goodbye!</Say>
+</Response>

--- a/twiml/testdata/simpleDialClient.xml
+++ b/twiml/testdata/simpleDialClient.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial hangupOnStar="false" answerOnBridge="false">
+    <Client>Testing</Client>
+  </Dial>
+</Response>

--- a/twiml/testdata/simpleDialConference.xml
+++ b/twiml/testdata/simpleDialConference.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial hangupOnStar="false" answerOnBridge="false">
+    <Conference muted="false" endConferenceOnExit="false">testConf</Conference>
+  </Dial>
+</Response>

--- a/twiml/testdata/simpleDialNumber.xml
+++ b/twiml/testdata/simpleDialNumber.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial hangupOnStar="false" answerOnBridge="false">
+    <Number>+14155555555</Number>
+  </Dial>
+</Response>

--- a/twiml/testdata/simpleDialQueue.xml
+++ b/twiml/testdata/simpleDialQueue.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial hangupOnStar="false" answerOnBridge="false">
+    <Queue>Testing</Queue>
+  </Dial>
+</Response>

--- a/twiml/testdata/simpleDialSIP.xml
+++ b/twiml/testdata/simpleDialSIP.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial hangupOnStar="false" answerOnBridge="false">
+    <Sip hangupOnStar="false" answerOnBridge="false">Testing</Sip>
+  </Dial>
+</Response>

--- a/twiml/testdata/simpledial.xml
+++ b/twiml/testdata/simpledial.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial hangupOnStar="false" answerOnBridge="false">415-555-5555</Dial>
+</Response>

--- a/twiml/testdata/simpleenqueue.xml
+++ b/twiml/testdata/simpleenqueue.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Enqueue>test</Enqueue>
+</Response>

--- a/twiml/testdata/simplegather.xml
+++ b/twiml/testdata/simplegather.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Gather></Gather>
+</Response>

--- a/twiml/testdata/simplepause.xml
+++ b/twiml/testdata/simplepause.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Pause></Pause>
+</Response>

--- a/twiml/testdata/simpleplay.xml
+++ b/twiml/testdata/simpleplay.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Play>https://example.org/audio.mp3</Play>
+</Response>

--- a/twiml/testdata/simplerecord.xml
+++ b/twiml/testdata/simplerecord.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Record transcribe="false"></Record>
+</Response>

--- a/twiml/testdata/simpleredirect.xml
+++ b/twiml/testdata/simpleredirect.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Redirect>https://example.org/redirect</Redirect>
+</Response>

--- a/twiml/testdata/simplereject.xml
+++ b/twiml/testdata/simplereject.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Reject></Reject>
+</Response>

--- a/twiml/testdata/simplesay.xml
+++ b/twiml/testdata/simplesay.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Say>Testing!</Say>
+</Response>

--- a/twiml/testdata/simplesms.xml
+++ b/twiml/testdata/simplesms.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Sms>Test message!</Sms>
+</Response>

--- a/twiml/trim_silence.go
+++ b/twiml/trim_silence.go
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import "encoding/xml"
+
+// Trim lets you specify whether to trim leading and trailing silence from your
+// audio files.
+type Trim uint8
+
+const (
+	// TrimSilence is the default and instructs Twilio to trim silence from
+	// recordings.
+	TrimSilence Trim = 1 << iota
+
+	// DoNotTrimSilence instructs Twilio to not trim silence from recordings.
+	DoNotTrimSilence
+)
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (t Trim) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: t.String(),
+	}
+
+	return attr, nil
+}
+
+func (t Trim) String() string {
+	switch t {
+	case TrimSilence:
+		return "trim-silence"
+	case DoNotTrimSilence:
+		return "do-not-trim"
+	default:
+		return ""
+	}
+}

--- a/twiml/trim_silence_test.go
+++ b/twiml/trim_silence_test.go
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestTrim_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   Trim
+		out  string
+	}{
+		{"Default (Zero Value) Trim should enable trimming", Trim(0), ""},
+		{"TrimSilence should enable trimming", TrimSilence, "trim-silence"},
+		{"DoNotTrimSilence should disable trimming", DoNotTrimSilence, "do-not-trim"},
+	}
+
+	for _, test := range tests {
+		if out := test.in.String(); out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nFinishOnKey(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestTrim_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "trim"}
+
+	tests := []struct {
+		desc     string
+		in       Trim
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Vault) voice should be Alice", Trim(0), attrName, attrName, ""},
+		{"TrimSilence should enable trimming", TrimSilence, attrName, attrName, "trim-silence"},
+		{"DoNotTrimSilence should disable trimming", DoNotTrimSilence, attrName, attrName, "do-not-trim"},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}

--- a/twiml/twiml.go
+++ b/twiml/twiml.go
@@ -1,0 +1,81 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+	"sync"
+)
+
+var bufferPool = sync.Pool{
+	New: func() interface{} {
+		return &bytes.Buffer{}
+	},
+}
+
+var xmlHeader = []byte(xml.Header)
+
+// Response represents a full TwiML response. TwiML is used to instruct Twilio
+// on what to do with a phone call.
+type Response struct {
+	XMLName xml.Name `xml:"Response"`
+	Verbs   []interface{}
+}
+
+// EncodeResponse takes a *Response instance and encodes it, writing it to w.
+func EncodeResponse(w io.Writer, r *Response) error {
+	// get a new XML encoder for writing to the buffer
+	// enable indenting of output
+	encoder := xml.NewEncoder(w)
+	encoder.Indent("", "  ")
+
+	// write the xml header to the buffer
+	w.Write(xmlHeader)
+
+	// encode the *Response in to XML and write it to the buffer
+	if err := encoder.Encode(r); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// MarshalResponse takes a *Response instance and renders it to XML.
+func MarshalResponse(r *Response) ([]byte, error) {
+	// get a new *bytes.Buffer from the pool
+	buf := bufferPool.Get().(*bytes.Buffer)
+
+	// defers are first in, last out...
+	// so when we return, this will call buf.Reset() first
+	defer bufferPool.Put(buf)
+	defer buf.Reset()
+
+	if err := EncodeResponse(buf, r); err != nil {
+		return nil, err
+	}
+
+	// copy the byte slice from the *bytes.Buffer as any changes to the buffer
+	// will impact the slice that .Bytes() returns
+	out := make([]byte, buf.Len())
+	copy(out, buf.Bytes())
+
+	return out, nil
+}
+
+// EncodeSlice takes a []inteface{}, allocates a *Response instances, and
+// encodes it to w.
+func EncodeSlice(w io.Writer, s []interface{}) error {
+	return EncodeResponse(w, &Response{Verbs: s})
+}
+
+// MarshalSlice takes a []interface{}, allocates a *Response instance, and calls
+// MarshalResponse with it.
+func MarshalSlice(s []interface{}) ([]byte, error) {
+	return MarshalResponse(&Response{Verbs: s})
+}

--- a/twiml/twiml_test.go
+++ b/twiml/twiml_test.go
@@ -1,0 +1,1476 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+)
+
+func readFileString(path string) (string, error) {
+	contents, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(contents), nil
+}
+
+func TestEncodeResponse(t *testing.T) {
+	simpleSay := &Say{Message: "Testing!"}
+	fullSay := &Say{
+		Message:  "Testing!",
+		Language: LangEnglishUS,
+		Loop:     2,
+		Voice:    VoiceAlice,
+	}
+	sliceSimpleSay := []interface{}{simpleSay}
+	sliceFullSay := []interface{}{fullSay}
+
+	simpleRecord := &Record{}
+	fullRecord := &Record{
+		Action:      "https://example.org/action",
+		Method:      "POST",
+		Timeout:     3,
+		FinishOnKey: FinishKeyAll,
+		MaxLength:   350,
+		PlayBeep:    true,
+		Trim:        TrimSilence,
+		RecordingStatusCallback:       "https://example.org/rsc",
+		RecordingStatusCallbackMethod: "POST",
+		Transcribe:                    true,
+		TranscribeCallback:            "https://example.org/tc",
+	}
+	sliceSimpleRecord := []interface{}{simpleRecord}
+	sliceFullRecord := []interface{}{fullRecord}
+
+	simpleReject := &Reject{}
+	fullReject := &Reject{Reason: RejectReasonRejected}
+	sliceSimpleReject := []interface{}{simpleReject}
+	sliceFullReject := []interface{}{fullReject}
+
+	fullHangup := &Hangup{}
+	sliceFullHangup := []interface{}{fullHangup}
+
+	simplePlay := &Play{URL: "https://example.org/audio.mp3"}
+	fullPlay := &Play{
+		URL:    "https://example.org/audio.mp3",
+		Loop:   2,
+		Digits: "0w42*",
+	}
+	sliceSimplePlay := []interface{}{simplePlay}
+	sliceFullPlay := []interface{}{fullPlay}
+
+	simplePause := &Pause{}
+	fullPause := &Pause{Length: 4}
+
+	sliceSimplePause := []interface{}{simplePause}
+	sliceFullPause := []interface{}{fullPause}
+
+	simpleSms := &Sms{Message: "Test message!"}
+	fullSms := &Sms{
+		Message:        "Test message!",
+		To:             "+14155555555",
+		From:           "+14155555656",
+		Action:         "https://example.org/action",
+		Method:         "POST",
+		StatusCallback: "https://example.org/scb",
+	}
+
+	sliceSimpleSms := []interface{}{simpleSms}
+	sliceFullSms := []interface{}{fullSms}
+
+	simpleRedirect := &Redirect{URL: "https://example.org/redirect"}
+	fullRedirect := &Redirect{
+		URL:    "https://example.org/redirect",
+		Method: "POST",
+	}
+
+	sliceSimpleRedirect := []interface{}{simpleRedirect}
+	sliceFullRedirect := []interface{}{fullRedirect}
+
+	fullLeave := &Leave{}
+	sliceFullLeave := []interface{}{fullLeave}
+
+	simpleEnqueue := &Enqueue{QueueName: "test"}
+	fullEnqueue := &Enqueue{
+		QueueName:     "test",
+		Action:        "https://example.org/action",
+		Method:        "POST",
+		WaitURL:       "https://example.org/wait",
+		WaitURLMethod: "GET",
+		WorkflowSID:   "WWtesting",
+	}
+
+	fullEnqueueWithTask := &Enqueue{
+		QueueName:     "test",
+		Task:          `{"test":"obj"}`,
+		Action:        "https://example.org/action",
+		Method:        "POST",
+		WaitURL:       "https://example.org/wait",
+		WaitURLMethod: "GET",
+		WorkflowSID:   "WWtesting",
+	}
+
+	sliceSimpleEnqueue := []interface{}{simpleEnqueue}
+	sliceFullEnqueue := []interface{}{fullEnqueue}
+	sliceFullEnqueueWithTask := []interface{}{fullEnqueueWithTask}
+
+	simpleGather := &Gather{}
+	fullGather := &Gather{
+		Input:                       GatherInputDTMFSpeech,
+		Action:                      "https://example.org/action",
+		Method:                      "POST",
+		Timeout:                     5,
+		FinishOnKey:                 FinishKeyStar | FinishKeyPound,
+		NumDigits:                   42,
+		PartialResultCallback:       "https://example.org/prc",
+		PartialResultCallbackMethod: "POST",
+		Language:                    LangEnglishUS,
+		Hints:                       "bacon ipsum, other stuff",
+		BargeIn:                     BargeInFalse,
+	}
+	fullGatherWithVerbs := &Gather{
+		Input:                       GatherInputDTMFSpeech,
+		Action:                      "https://example.org/action",
+		Method:                      "POST",
+		Timeout:                     5,
+		FinishOnKey:                 FinishKeyStar | FinishKeyPound,
+		NumDigits:                   42,
+		PartialResultCallback:       "https://example.org/prc",
+		PartialResultCallbackMethod: "POST",
+		Language:                    LangEnglishUS,
+		Hints:                       "bacon ipsum, other stuff",
+		BargeIn:                     BargeInFalse,
+		NestedVerbs: []interface{}{
+			fullSay, fullPlay, fullPause,
+		},
+	}
+
+	sliceSimpleGather := []interface{}{simpleGather}
+	sliceFullGather := []interface{}{fullGather}
+	sliceFullGatherWithVerbs := []interface{}{fullGatherWithVerbs}
+
+	simpleDial := &Dial{Number: "415-555-5555"}
+	fullDial := &Dial{
+		Number:       "415-555-5555",
+		Action:       "https://example.org/action",
+		Method:       "POST",
+		Timeout:      5,
+		HangupOnStar: true,
+		TimeLimit:    10,
+		CallerID:     "+14155555555",
+		Record:       DialRecordFromRingingDual,
+		Trim:         TrimSilence,
+		RecordingStatusCallback:       "https://example.org/rsc",
+		RecordingStatusCallbackMethod: "POST",
+		AnswerOnBridge:                true,
+		RingTone:                      RingToneUSOld,
+	}
+
+	sliceSimpleDial := []interface{}{simpleDial}
+	sliceFullDial := []interface{}{fullDial}
+
+	simpleDialClient := &DialClient{ClientName: "Testing"}
+	sdcDial := &Dial{Nouns: []interface{}{simpleDialClient}}
+	sliceSimpleDialClient := []interface{}{sdcDial}
+
+	fullDialClient := &DialClient{
+		ClientName:           "Testing",
+		URL:                  "https://example.org/url",
+		Method:               "POST",
+		StatusCallbackEvent:  StatusCallbackAll,
+		StatusCallback:       "https://example.org/scb",
+		StatusCallbackMethod: "POST",
+	}
+	fdcDial := &Dial{Nouns: []interface{}{fullDialClient}}
+	sliceFullDialClient := []interface{}{fdcDial}
+
+	simpleDialQueue := &DialQueue{QueueName: "Testing"}
+	sdqDial := &Dial{Nouns: []interface{}{simpleDialQueue}}
+	sliceSimpleDialQueue := []interface{}{sdqDial}
+
+	fullDialQueue := &DialQueue{
+		QueueName:           "Testing",
+		URL:                 "https://example.org/url",
+		Method:              "POST",
+		ReservationSID:      "reservationSid",
+		PostWorkActivitySID: "postWorkActivitySid",
+	}
+	fdqDial := &Dial{Nouns: []interface{}{fullDialQueue}}
+	sliceFullDialQueue := []interface{}{fdqDial}
+
+	fullDialSIM := &DialSIM{SIM: "Testing"}
+	fdsDial := &Dial{Nouns: []interface{}{fullDialSIM}}
+	sliceFullDialSIM := []interface{}{fdsDial}
+
+	simpleDialNumber := &DialNumber{Number: "+14155555555"}
+	sdnDial := &Dial{Nouns: []interface{}{simpleDialNumber}}
+	sliceSimpleDialNumber := []interface{}{sdnDial}
+
+	fullDialNumber := &DialNumber{
+		Number:               "+14155555555",
+		SendDigits:           "ww42",
+		URL:                  "https://example.org/url",
+		Method:               "POST",
+		StatusCallbackEvent:  StatusCallbackAll,
+		StatusCallback:       "https://example.org/scb",
+		StatusCallbackMethod: "POST",
+	}
+	fdnDial := &Dial{Nouns: []interface{}{fullDialNumber}}
+	sliceFullDialNumber := []interface{}{fdnDial}
+
+	simpleDialConference := &DialConference{Name: "testConf"}
+	sdconfDial := &Dial{Nouns: []interface{}{simpleDialConference}}
+	sliceSimpleDialConference := []interface{}{sdconfDial}
+
+	fullDialConference := &DialConference{
+		Name:  "testConf",
+		Muted: true,
+		Beep:  ConfBeepTrue,
+		StartConferenceOnEnter:        ConfStartOnEnterTrue,
+		EndConferenceOnExit:           true,
+		WaitURL:                       "https://example.org/wait",
+		WaitMethod:                    "POST",
+		MaxParticipants:               42, // because Twilio doesn't allow tree-fiddy
+		Record:                        ConfRecordFromStart,
+		Region:                        ConfRegionJapan,
+		Trim:                          TrimSilence,
+		Whisper:                       "testWhisper",
+		StatusCallbackEvent:           ConfStatusCallbackAll,
+		StatusCallbackMethod:          "POST",
+		RecordingStatusCallback:       "https://example.org/rsc",
+		RecordingStatusCallbackMethod: "POST",
+	}
+	fdconfDial := &Dial{Nouns: []interface{}{fullDialConference}}
+	sliceFullDialConference := []interface{}{fdconfDial}
+
+	simpleDialSIP := &DialSIP{URI: "Testing"}
+	sdsipDial := &Dial{Nouns: []interface{}{simpleDialSIP}}
+	sliceSimpleDialSIP := []interface{}{sdsipDial}
+
+	fullDialSIP := &DialSIP{
+		URI:                  "Testing",
+		Username:             "testUser",
+		Password:             "testPass",
+		URL:                  "https://example.org/url",
+		Method:               "POST",
+		StatusCallbackEvent:  StatusCallbackAll,
+		StatusCallback:       "https://example.org/scb",
+		StatusCallbackMethod: "POST",
+		Timeout:              42,
+		HangupOnStar:         true,
+		TimeLimit:            84,
+		CallerID:             "theckman",
+		Record:               DialRecordFromRingingDual,
+		Trim:                 TrimSilence,
+		RecordingStatusCallback:       "https://example.org/rscb",
+		RecordingStatusCallbackMethod: "POST",
+		AnswerOnBridge:                true,
+		RingTone:                      RingToneJapan,
+	}
+	fdsipDial := &Dial{Nouns: []interface{}{fullDialSIP}}
+	sliceFullDialSIP := []interface{}{fdsipDial}
+
+	dialWithNouns := &Dial{Nouns: []interface{}{fullDialSIP, fullDialQueue}}
+	sliceDialWithNouns := []interface{}{dialWithNouns}
+
+	anotherSimpleSay := &Say{Message: "Goodbye!"}
+	anotherFullSay := &Say{
+		Message:  "Goodbye!",
+		Language: LangEnglishAustralia,
+		Loop:     3,
+		Voice:    VoiceAlice,
+	}
+
+	sliceSimple := []interface{}{
+		simpleSay, simpleRecord, simpleReject, fullHangup,
+		simplePlay, simplePause, simpleSms, simpleRedirect,
+		fullLeave, simpleEnqueue, simpleGather, simpleDial,
+		anotherSimpleSay,
+	}
+
+	sliceFull := []interface{}{
+		fullSay, fullRecord, fullReject, fullHangup,
+		fullPlay, fullPause, fullSms, fullRedirect,
+		fullLeave, fullEnqueue, fullGather, fullDial,
+		anotherFullSay,
+	}
+
+	//
+	// Test loop
+	//
+	tests := []struct {
+		desc        string
+		in          *Response
+		outfilePath string
+	}{
+		{"Response with one simple <Say> instruction", &Response{Verbs: sliceSimpleSay}, "simplesay.xml"},
+		{"Response with one full <Say> instruction", &Response{Verbs: sliceFullSay}, "fullsay.xml"},
+		{"Response with one simple <Record> instruction", &Response{Verbs: sliceSimpleRecord}, "simplerecord.xml"},
+		{"Response with one full <Record> instruction", &Response{Verbs: sliceFullRecord}, "fullrecord.xml"},
+		{"Response with one simple <Reject> instruction", &Response{Verbs: sliceSimpleReject}, "simplereject.xml"},
+		{"Response with one full <Reject> instruction", &Response{Verbs: sliceFullReject}, "fullreject.xml"},
+		{"Response with one full <Hangup> instruction", &Response{Verbs: sliceFullHangup}, "fullhangup.xml"},
+		{"Response with one simple <Play> instruction", &Response{Verbs: sliceSimplePlay}, "simpleplay.xml"},
+		{"Response with one full <Play> instruction", &Response{Verbs: sliceFullPlay}, "fullplay.xml"},
+		{"Response with one simple <Pause> instruction", &Response{Verbs: sliceSimplePause}, "simplepause.xml"},
+		{"Response with one full <Pause> instruction", &Response{Verbs: sliceFullPause}, "fullpause.xml"},
+		{"Response with one simple <Sms> instruction", &Response{Verbs: sliceSimpleSms}, "simplesms.xml"},
+		{"Response with one full <Sms> instruction", &Response{Verbs: sliceFullSms}, "fullsms.xml"},
+		{"Response with one simple <Redirect> instruction", &Response{Verbs: sliceSimpleRedirect}, "simpleredirect.xml"},
+		{"Response with one full <Redirect> instruction", &Response{Verbs: sliceFullRedirect}, "fullredirect.xml"},
+		{"Response with one full <Leave> instruction", &Response{Verbs: sliceFullLeave}, "fullleave.xml"},
+		{"Response with one simple <Enqueue> instruction", &Response{Verbs: sliceSimpleEnqueue}, "simpleenqueue.xml"},
+		{"Response with one full <Enqueue> instruction", &Response{Verbs: sliceFullEnqueue}, "fullenqueue.xml"},
+		{"Response with one full <Enqueue> instruction with a Task", &Response{Verbs: sliceFullEnqueueWithTask}, "fullenqueuewithtask.xml"},
+		{"Response with one simple <Gather> instruction", &Response{Verbs: sliceSimpleGather}, "simplegather.xml"},
+		{"Response with one full <Gather> instruction", &Response{Verbs: sliceFullGather}, "fullgather.xml"},
+		{"Response with one full <Gather> instruction with verbs", &Response{Verbs: sliceFullGatherWithVerbs}, "fullgatherwithverbs.xml"},
+		{"Response with one simple <Dial> instruction", &Response{Verbs: sliceSimpleDial}, "simpledial.xml"},
+		{"Response with one full <Dial> instruction", &Response{Verbs: sliceFullDial}, "fulldial.xml"},
+		{"Response with one simple <Dial><Client> instruction", &Response{Verbs: sliceSimpleDialClient}, "simpleDialClient.xml"},
+		{"Response with one full <Dial><Client> instruction", &Response{Verbs: sliceFullDialClient}, "fullDialClient.xml"},
+		{"Response with one simple <Dial><Queue> instruction", &Response{Verbs: sliceSimpleDialQueue}, "simpleDialQueue.xml"},
+		{"Response with one full <Dial><Queue> instruction", &Response{Verbs: sliceFullDialQueue}, "fullDialQueue.xml"},
+		{"Response with one full <Dial><Sim> instruction", &Response{Verbs: sliceFullDialSIM}, "fullDialSIM.xml"},
+		{"Response with one simple <Dial><Number> instruction", &Response{Verbs: sliceSimpleDialNumber}, "simpleDialNumber.xml"},
+		{"Response with one full <Dial><Number> instruction", &Response{Verbs: sliceFullDialNumber}, "fullDialNumber.xml"},
+		{"Response with one simple <Dial><Conference> instruction", &Response{Verbs: sliceSimpleDialConference}, "simpleDialConference.xml"},
+		{"Response with one full <Dial><Conference> instruction", &Response{Verbs: sliceFullDialConference}, "fullDialConference.xml"},
+		{"Response with one simple <Dial><Sip> instruction", &Response{Verbs: sliceSimpleDialSIP}, "simpleDialSIP.xml"},
+		{"Response with one full <Dial><Sip> instruction", &Response{Verbs: sliceFullDialSIP}, "fullDialSIP.xml"},
+		{"Response with one <Dial> with multiple nouns instruction", &Response{Verbs: sliceDialWithNouns}, "fullDialWithNouns.xml"},
+		{"Response with all simple instructions", &Response{Verbs: sliceSimple}, "simple.xml"},
+		{"Response with all full instructions", &Response{Verbs: sliceFull}, "full.xml"},
+	}
+
+	for _, test := range tests {
+		tdPath := filepath.Join("testdata", test.outfilePath)
+		testExpectedOut, err := readFileString(tdPath)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nUnexpected error reading testdata file (%s): %s",
+				test.desc, tdPath, err.Error(),
+			)
+			continue
+		}
+
+		b := &bytes.Buffer{}
+
+		err = EncodeResponse(b, test.in)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nEncodeResponse() Unexpected Error: %s",
+				test.desc, err,
+			)
+			continue
+		}
+
+		if out := b.String(); out != testExpectedOut {
+			t.Errorf(
+				"\nDescription: %s\nRendered XML (quoted with `):\n`%s`\n\nWant XML (quoted with `):\n`%s`",
+				test.desc, out, testExpectedOut,
+			)
+			continue
+		}
+	}
+}
+
+func TestMarshalResponse(t *testing.T) {
+	simpleSay := &Say{Message: "Testing!"}
+	fullSay := &Say{
+		Message:  "Testing!",
+		Language: LangEnglishUS,
+		Loop:     2,
+		Voice:    VoiceAlice,
+	}
+	sliceSimpleSay := []interface{}{simpleSay}
+	sliceFullSay := []interface{}{fullSay}
+
+	simpleRecord := &Record{}
+	fullRecord := &Record{
+		Action:      "https://example.org/action",
+		Method:      "POST",
+		Timeout:     3,
+		FinishOnKey: FinishKeyAll,
+		MaxLength:   350,
+		PlayBeep:    true,
+		Trim:        TrimSilence,
+		RecordingStatusCallback:       "https://example.org/rsc",
+		RecordingStatusCallbackMethod: "POST",
+		Transcribe:                    true,
+		TranscribeCallback:            "https://example.org/tc",
+	}
+	sliceSimpleRecord := []interface{}{simpleRecord}
+	sliceFullRecord := []interface{}{fullRecord}
+
+	simpleReject := &Reject{}
+	fullReject := &Reject{Reason: RejectReasonRejected}
+	sliceSimpleReject := []interface{}{simpleReject}
+	sliceFullReject := []interface{}{fullReject}
+
+	fullHangup := &Hangup{}
+	sliceFullHangup := []interface{}{fullHangup}
+
+	simplePlay := &Play{URL: "https://example.org/audio.mp3"}
+	fullPlay := &Play{
+		URL:    "https://example.org/audio.mp3",
+		Loop:   2,
+		Digits: "0w42*",
+	}
+	sliceSimplePlay := []interface{}{simplePlay}
+	sliceFullPlay := []interface{}{fullPlay}
+
+	simplePause := &Pause{}
+	fullPause := &Pause{Length: 4}
+
+	sliceSimplePause := []interface{}{simplePause}
+	sliceFullPause := []interface{}{fullPause}
+
+	simpleSms := &Sms{Message: "Test message!"}
+	fullSms := &Sms{
+		Message:        "Test message!",
+		To:             "+14155555555",
+		From:           "+14155555656",
+		Action:         "https://example.org/action",
+		Method:         "POST",
+		StatusCallback: "https://example.org/scb",
+	}
+
+	sliceSimpleSms := []interface{}{simpleSms}
+	sliceFullSms := []interface{}{fullSms}
+
+	simpleRedirect := &Redirect{URL: "https://example.org/redirect"}
+	fullRedirect := &Redirect{
+		URL:    "https://example.org/redirect",
+		Method: "POST",
+	}
+
+	sliceSimpleRedirect := []interface{}{simpleRedirect}
+	sliceFullRedirect := []interface{}{fullRedirect}
+
+	fullLeave := &Leave{}
+	sliceFullLeave := []interface{}{fullLeave}
+
+	simpleEnqueue := &Enqueue{QueueName: "test"}
+	fullEnqueue := &Enqueue{
+		QueueName:     "test",
+		Action:        "https://example.org/action",
+		Method:        "POST",
+		WaitURL:       "https://example.org/wait",
+		WaitURLMethod: "GET",
+		WorkflowSID:   "WWtesting",
+	}
+
+	fullEnqueueWithTask := &Enqueue{
+		QueueName:     "test",
+		Task:          `{"test":"obj"}`,
+		Action:        "https://example.org/action",
+		Method:        "POST",
+		WaitURL:       "https://example.org/wait",
+		WaitURLMethod: "GET",
+		WorkflowSID:   "WWtesting",
+	}
+
+	sliceSimpleEnqueue := []interface{}{simpleEnqueue}
+	sliceFullEnqueue := []interface{}{fullEnqueue}
+	sliceFullEnqueueWithTask := []interface{}{fullEnqueueWithTask}
+
+	simpleGather := &Gather{}
+	fullGather := &Gather{
+		Input:                       GatherInputDTMFSpeech,
+		Action:                      "https://example.org/action",
+		Method:                      "POST",
+		Timeout:                     5,
+		FinishOnKey:                 FinishKeyStar | FinishKeyPound,
+		NumDigits:                   42,
+		PartialResultCallback:       "https://example.org/prc",
+		PartialResultCallbackMethod: "POST",
+		Language:                    LangEnglishUS,
+		Hints:                       "bacon ipsum, other stuff",
+		BargeIn:                     BargeInFalse,
+	}
+	fullGatherWithVerbs := &Gather{
+		Input:                       GatherInputDTMFSpeech,
+		Action:                      "https://example.org/action",
+		Method:                      "POST",
+		Timeout:                     5,
+		FinishOnKey:                 FinishKeyStar | FinishKeyPound,
+		NumDigits:                   42,
+		PartialResultCallback:       "https://example.org/prc",
+		PartialResultCallbackMethod: "POST",
+		Language:                    LangEnglishUS,
+		Hints:                       "bacon ipsum, other stuff",
+		BargeIn:                     BargeInFalse,
+		NestedVerbs: []interface{}{
+			fullSay, fullPlay, fullPause,
+		},
+	}
+
+	sliceSimpleGather := []interface{}{simpleGather}
+	sliceFullGather := []interface{}{fullGather}
+	sliceFullGatherWithVerbs := []interface{}{fullGatherWithVerbs}
+
+	simpleDial := &Dial{Number: "415-555-5555"}
+	fullDial := &Dial{
+		Number:       "415-555-5555",
+		Action:       "https://example.org/action",
+		Method:       "POST",
+		Timeout:      5,
+		HangupOnStar: true,
+		TimeLimit:    10,
+		CallerID:     "+14155555555",
+		Record:       DialRecordFromRingingDual,
+		Trim:         TrimSilence,
+		RecordingStatusCallback:       "https://example.org/rsc",
+		RecordingStatusCallbackMethod: "POST",
+		AnswerOnBridge:                true,
+		RingTone:                      RingToneUSOld,
+	}
+
+	sliceSimpleDial := []interface{}{simpleDial}
+	sliceFullDial := []interface{}{fullDial}
+
+	simpleDialClient := &DialClient{ClientName: "Testing"}
+	sdcDial := &Dial{Nouns: []interface{}{simpleDialClient}}
+	sliceSimpleDialClient := []interface{}{sdcDial}
+
+	fullDialClient := &DialClient{
+		ClientName:           "Testing",
+		URL:                  "https://example.org/url",
+		Method:               "POST",
+		StatusCallbackEvent:  StatusCallbackAll,
+		StatusCallback:       "https://example.org/scb",
+		StatusCallbackMethod: "POST",
+	}
+	fdcDial := &Dial{Nouns: []interface{}{fullDialClient}}
+	sliceFullDialClient := []interface{}{fdcDial}
+
+	simpleDialQueue := &DialQueue{QueueName: "Testing"}
+	sdqDial := &Dial{Nouns: []interface{}{simpleDialQueue}}
+	sliceSimpleDialQueue := []interface{}{sdqDial}
+
+	fullDialQueue := &DialQueue{
+		QueueName:           "Testing",
+		URL:                 "https://example.org/url",
+		Method:              "POST",
+		ReservationSID:      "reservationSid",
+		PostWorkActivitySID: "postWorkActivitySid",
+	}
+	fdqDial := &Dial{Nouns: []interface{}{fullDialQueue}}
+	sliceFullDialQueue := []interface{}{fdqDial}
+
+	fullDialSIM := &DialSIM{SIM: "Testing"}
+	fdsDial := &Dial{Nouns: []interface{}{fullDialSIM}}
+	sliceFullDialSIM := []interface{}{fdsDial}
+
+	simpleDialNumber := &DialNumber{Number: "+14155555555"}
+	sdnDial := &Dial{Nouns: []interface{}{simpleDialNumber}}
+	sliceSimpleDialNumber := []interface{}{sdnDial}
+
+	fullDialNumber := &DialNumber{
+		Number:               "+14155555555",
+		SendDigits:           "ww42",
+		URL:                  "https://example.org/url",
+		Method:               "POST",
+		StatusCallbackEvent:  StatusCallbackAll,
+		StatusCallback:       "https://example.org/scb",
+		StatusCallbackMethod: "POST",
+	}
+	fdnDial := &Dial{Nouns: []interface{}{fullDialNumber}}
+	sliceFullDialNumber := []interface{}{fdnDial}
+
+	simpleDialConference := &DialConference{Name: "testConf"}
+	sdconfDial := &Dial{Nouns: []interface{}{simpleDialConference}}
+	sliceSimpleDialConference := []interface{}{sdconfDial}
+
+	fullDialConference := &DialConference{
+		Name:  "testConf",
+		Muted: true,
+		Beep:  ConfBeepTrue,
+		StartConferenceOnEnter:        ConfStartOnEnterTrue,
+		EndConferenceOnExit:           true,
+		WaitURL:                       "https://example.org/wait",
+		WaitMethod:                    "POST",
+		MaxParticipants:               42, // because Twilio doesn't allow tree-fiddy
+		Record:                        ConfRecordFromStart,
+		Region:                        ConfRegionJapan,
+		Trim:                          TrimSilence,
+		Whisper:                       "testWhisper",
+		StatusCallbackEvent:           ConfStatusCallbackAll,
+		StatusCallbackMethod:          "POST",
+		RecordingStatusCallback:       "https://example.org/rsc",
+		RecordingStatusCallbackMethod: "POST",
+	}
+	fdconfDial := &Dial{Nouns: []interface{}{fullDialConference}}
+	sliceFullDialConference := []interface{}{fdconfDial}
+
+	simpleDialSIP := &DialSIP{URI: "Testing"}
+	sdsipDial := &Dial{Nouns: []interface{}{simpleDialSIP}}
+	sliceSimpleDialSIP := []interface{}{sdsipDial}
+
+	fullDialSIP := &DialSIP{
+		URI:                  "Testing",
+		Username:             "testUser",
+		Password:             "testPass",
+		URL:                  "https://example.org/url",
+		Method:               "POST",
+		StatusCallbackEvent:  StatusCallbackAll,
+		StatusCallback:       "https://example.org/scb",
+		StatusCallbackMethod: "POST",
+		Timeout:              42,
+		HangupOnStar:         true,
+		TimeLimit:            84,
+		CallerID:             "theckman",
+		Record:               DialRecordFromRingingDual,
+		Trim:                 TrimSilence,
+		RecordingStatusCallback:       "https://example.org/rscb",
+		RecordingStatusCallbackMethod: "POST",
+		AnswerOnBridge:                true,
+		RingTone:                      RingToneJapan,
+	}
+	fdsipDial := &Dial{Nouns: []interface{}{fullDialSIP}}
+	sliceFullDialSIP := []interface{}{fdsipDial}
+
+	dialWithNouns := &Dial{Nouns: []interface{}{fullDialSIP, fullDialQueue}}
+	sliceDialWithNouns := []interface{}{dialWithNouns}
+
+	anotherSimpleSay := &Say{Message: "Goodbye!"}
+	anotherFullSay := &Say{
+		Message:  "Goodbye!",
+		Language: LangEnglishAustralia,
+		Loop:     3,
+		Voice:    VoiceAlice,
+	}
+
+	sliceSimple := []interface{}{
+		simpleSay, simpleRecord, simpleReject, fullHangup,
+		simplePlay, simplePause, simpleSms, simpleRedirect,
+		fullLeave, simpleEnqueue, simpleGather, simpleDial,
+		anotherSimpleSay,
+	}
+
+	sliceFull := []interface{}{
+		fullSay, fullRecord, fullReject, fullHangup,
+		fullPlay, fullPause, fullSms, fullRedirect,
+		fullLeave, fullEnqueue, fullGather, fullDial,
+		anotherFullSay,
+	}
+
+	//
+	// Test loop
+	//
+	tests := []struct {
+		desc        string
+		in          *Response
+		outfilePath string
+	}{
+		{"Response with one simple <Say> instruction", &Response{Verbs: sliceSimpleSay}, "simplesay.xml"},
+		{"Response with one full <Say> instruction", &Response{Verbs: sliceFullSay}, "fullsay.xml"},
+		{"Response with one simple <Record> instruction", &Response{Verbs: sliceSimpleRecord}, "simplerecord.xml"},
+		{"Response with one full <Record> instruction", &Response{Verbs: sliceFullRecord}, "fullrecord.xml"},
+		{"Response with one simple <Reject> instruction", &Response{Verbs: sliceSimpleReject}, "simplereject.xml"},
+		{"Response with one full <Reject> instruction", &Response{Verbs: sliceFullReject}, "fullreject.xml"},
+		{"Response with one full <Hangup> instruction", &Response{Verbs: sliceFullHangup}, "fullhangup.xml"},
+		{"Response with one simple <Play> instruction", &Response{Verbs: sliceSimplePlay}, "simpleplay.xml"},
+		{"Response with one full <Play> instruction", &Response{Verbs: sliceFullPlay}, "fullplay.xml"},
+		{"Response with one simple <Pause> instruction", &Response{Verbs: sliceSimplePause}, "simplepause.xml"},
+		{"Response with one full <Pause> instruction", &Response{Verbs: sliceFullPause}, "fullpause.xml"},
+		{"Response with one simple <Sms> instruction", &Response{Verbs: sliceSimpleSms}, "simplesms.xml"},
+		{"Response with one full <Sms> instruction", &Response{Verbs: sliceFullSms}, "fullsms.xml"},
+		{"Response with one simple <Redirect> instruction", &Response{Verbs: sliceSimpleRedirect}, "simpleredirect.xml"},
+		{"Response with one full <Redirect> instruction", &Response{Verbs: sliceFullRedirect}, "fullredirect.xml"},
+		{"Response with one full <Leave> instruction", &Response{Verbs: sliceFullLeave}, "fullleave.xml"},
+		{"Response with one simple <Enqueue> instruction", &Response{Verbs: sliceSimpleEnqueue}, "simpleenqueue.xml"},
+		{"Response with one full <Enqueue> instruction", &Response{Verbs: sliceFullEnqueue}, "fullenqueue.xml"},
+		{"Response with one full <Enqueue> instruction with a Task", &Response{Verbs: sliceFullEnqueueWithTask}, "fullenqueuewithtask.xml"},
+		{"Response with one simple <Gather> instruction", &Response{Verbs: sliceSimpleGather}, "simplegather.xml"},
+		{"Response with one full <Gather> instruction", &Response{Verbs: sliceFullGather}, "fullgather.xml"},
+		{"Response with one full <Gather> instruction with verbs", &Response{Verbs: sliceFullGatherWithVerbs}, "fullgatherwithverbs.xml"},
+		{"Response with one simple <Dial> instruction", &Response{Verbs: sliceSimpleDial}, "simpledial.xml"},
+		{"Response with one full <Dial> instruction", &Response{Verbs: sliceFullDial}, "fulldial.xml"},
+		{"Response with one simple <Dial><Client> instruction", &Response{Verbs: sliceSimpleDialClient}, "simpleDialClient.xml"},
+		{"Response with one full <Dial><Client> instruction", &Response{Verbs: sliceFullDialClient}, "fullDialClient.xml"},
+		{"Response with one simple <Dial><Queue> instruction", &Response{Verbs: sliceSimpleDialQueue}, "simpleDialQueue.xml"},
+		{"Response with one full <Dial><Queue> instruction", &Response{Verbs: sliceFullDialQueue}, "fullDialQueue.xml"},
+		{"Response with one full <Dial><Sim> instruction", &Response{Verbs: sliceFullDialSIM}, "fullDialSIM.xml"},
+		{"Response with one simple <Dial><Number> instruction", &Response{Verbs: sliceSimpleDialNumber}, "simpleDialNumber.xml"},
+		{"Response with one full <Dial><Number> instruction", &Response{Verbs: sliceFullDialNumber}, "fullDialNumber.xml"},
+		{"Response with one simple <Dial><Conference> instruction", &Response{Verbs: sliceSimpleDialConference}, "simpleDialConference.xml"},
+		{"Response with one full <Dial><Conference> instruction", &Response{Verbs: sliceFullDialConference}, "fullDialConference.xml"},
+		{"Response with one simple <Dial><Sip> instruction", &Response{Verbs: sliceSimpleDialSIP}, "simpleDialSIP.xml"},
+		{"Response with one full <Dial><Sip> instruction", &Response{Verbs: sliceFullDialSIP}, "fullDialSIP.xml"},
+		{"Response with one <Dial> with multiple nouns instruction", &Response{Verbs: sliceDialWithNouns}, "fullDialWithNouns.xml"},
+		{"Response with all simple instructions", &Response{Verbs: sliceSimple}, "simple.xml"},
+		{"Response with all full instructions", &Response{Verbs: sliceFull}, "full.xml"},
+	}
+
+	for _, test := range tests {
+		tdPath := filepath.Join("testdata", test.outfilePath)
+		testExpectedOut, err := readFileString(tdPath)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nUnexpected error reading testdata file (%s): %s",
+				test.desc, tdPath, err.Error(),
+			)
+			continue
+		}
+
+		renderedXML, err := MarshalResponse(test.in)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nEncodeResponse() Unexpected Error: %s",
+				test.desc, err,
+			)
+			continue
+		}
+
+		if out := string(renderedXML); out != testExpectedOut {
+			t.Errorf(
+				"\nDescription: %s\nRendered XML (quoted with `):\n`%s`\n\nWant XML (quoted with `):\n`%s`",
+				test.desc, out, testExpectedOut,
+			)
+			continue
+		}
+	}
+}
+
+//
+// DIVIDE
+//
+
+func TestEncodeSlice(t *testing.T) {
+	simpleSay := &Say{Message: "Testing!"}
+	fullSay := &Say{
+		Message:  "Testing!",
+		Language: LangEnglishUS,
+		Loop:     2,
+		Voice:    VoiceAlice,
+	}
+	sliceSimpleSay := []interface{}{simpleSay}
+	sliceFullSay := []interface{}{fullSay}
+
+	simpleRecord := &Record{}
+	fullRecord := &Record{
+		Action:      "https://example.org/action",
+		Method:      "POST",
+		Timeout:     3,
+		FinishOnKey: FinishKeyAll,
+		MaxLength:   350,
+		PlayBeep:    true,
+		Trim:        TrimSilence,
+		RecordingStatusCallback:       "https://example.org/rsc",
+		RecordingStatusCallbackMethod: "POST",
+		Transcribe:                    true,
+		TranscribeCallback:            "https://example.org/tc",
+	}
+	sliceSimpleRecord := []interface{}{simpleRecord}
+	sliceFullRecord := []interface{}{fullRecord}
+
+	simpleReject := &Reject{}
+	fullReject := &Reject{Reason: RejectReasonRejected}
+	sliceSimpleReject := []interface{}{simpleReject}
+	sliceFullReject := []interface{}{fullReject}
+
+	fullHangup := &Hangup{}
+	sliceFullHangup := []interface{}{fullHangup}
+
+	simplePlay := &Play{URL: "https://example.org/audio.mp3"}
+	fullPlay := &Play{
+		URL:    "https://example.org/audio.mp3",
+		Loop:   2,
+		Digits: "0w42*",
+	}
+	sliceSimplePlay := []interface{}{simplePlay}
+	sliceFullPlay := []interface{}{fullPlay}
+
+	simplePause := &Pause{}
+	fullPause := &Pause{Length: 4}
+
+	sliceSimplePause := []interface{}{simplePause}
+	sliceFullPause := []interface{}{fullPause}
+
+	simpleSms := &Sms{Message: "Test message!"}
+	fullSms := &Sms{
+		Message:        "Test message!",
+		To:             "+14155555555",
+		From:           "+14155555656",
+		Action:         "https://example.org/action",
+		Method:         "POST",
+		StatusCallback: "https://example.org/scb",
+	}
+
+	sliceSimpleSms := []interface{}{simpleSms}
+	sliceFullSms := []interface{}{fullSms}
+
+	simpleRedirect := &Redirect{URL: "https://example.org/redirect"}
+	fullRedirect := &Redirect{
+		URL:    "https://example.org/redirect",
+		Method: "POST",
+	}
+
+	sliceSimpleRedirect := []interface{}{simpleRedirect}
+	sliceFullRedirect := []interface{}{fullRedirect}
+
+	fullLeave := &Leave{}
+	sliceFullLeave := []interface{}{fullLeave}
+
+	simpleEnqueue := &Enqueue{QueueName: "test"}
+	fullEnqueue := &Enqueue{
+		QueueName:     "test",
+		Action:        "https://example.org/action",
+		Method:        "POST",
+		WaitURL:       "https://example.org/wait",
+		WaitURLMethod: "GET",
+		WorkflowSID:   "WWtesting",
+	}
+
+	fullEnqueueWithTask := &Enqueue{
+		QueueName:     "test",
+		Task:          `{"test":"obj"}`,
+		Action:        "https://example.org/action",
+		Method:        "POST",
+		WaitURL:       "https://example.org/wait",
+		WaitURLMethod: "GET",
+		WorkflowSID:   "WWtesting",
+	}
+
+	sliceSimpleEnqueue := []interface{}{simpleEnqueue}
+	sliceFullEnqueue := []interface{}{fullEnqueue}
+	sliceFullEnqueueWithTask := []interface{}{fullEnqueueWithTask}
+
+	simpleGather := &Gather{}
+	fullGather := &Gather{
+		Input:                       GatherInputDTMFSpeech,
+		Action:                      "https://example.org/action",
+		Method:                      "POST",
+		Timeout:                     5,
+		FinishOnKey:                 FinishKeyStar | FinishKeyPound,
+		NumDigits:                   42,
+		PartialResultCallback:       "https://example.org/prc",
+		PartialResultCallbackMethod: "POST",
+		Language:                    LangEnglishUS,
+		Hints:                       "bacon ipsum, other stuff",
+		BargeIn:                     BargeInFalse,
+	}
+	fullGatherWithVerbs := &Gather{
+		Input:                       GatherInputDTMFSpeech,
+		Action:                      "https://example.org/action",
+		Method:                      "POST",
+		Timeout:                     5,
+		FinishOnKey:                 FinishKeyStar | FinishKeyPound,
+		NumDigits:                   42,
+		PartialResultCallback:       "https://example.org/prc",
+		PartialResultCallbackMethod: "POST",
+		Language:                    LangEnglishUS,
+		Hints:                       "bacon ipsum, other stuff",
+		BargeIn:                     BargeInFalse,
+		NestedVerbs: []interface{}{
+			fullSay, fullPlay, fullPause,
+		},
+	}
+
+	sliceSimpleGather := []interface{}{simpleGather}
+	sliceFullGather := []interface{}{fullGather}
+	sliceFullGatherWithVerbs := []interface{}{fullGatherWithVerbs}
+
+	simpleDial := &Dial{Number: "415-555-5555"}
+	fullDial := &Dial{
+		Number:       "415-555-5555",
+		Action:       "https://example.org/action",
+		Method:       "POST",
+		Timeout:      5,
+		HangupOnStar: true,
+		TimeLimit:    10,
+		CallerID:     "+14155555555",
+		Record:       DialRecordFromRingingDual,
+		Trim:         TrimSilence,
+		RecordingStatusCallback:       "https://example.org/rsc",
+		RecordingStatusCallbackMethod: "POST",
+		AnswerOnBridge:                true,
+		RingTone:                      RingToneUSOld,
+	}
+
+	sliceSimpleDial := []interface{}{simpleDial}
+	sliceFullDial := []interface{}{fullDial}
+
+	simpleDialClient := &DialClient{ClientName: "Testing"}
+	sdcDial := &Dial{Nouns: []interface{}{simpleDialClient}}
+	sliceSimpleDialClient := []interface{}{sdcDial}
+
+	fullDialClient := &DialClient{
+		ClientName:           "Testing",
+		URL:                  "https://example.org/url",
+		Method:               "POST",
+		StatusCallbackEvent:  StatusCallbackAll,
+		StatusCallback:       "https://example.org/scb",
+		StatusCallbackMethod: "POST",
+	}
+	fdcDial := &Dial{Nouns: []interface{}{fullDialClient}}
+	sliceFullDialClient := []interface{}{fdcDial}
+
+	simpleDialQueue := &DialQueue{QueueName: "Testing"}
+	sdqDial := &Dial{Nouns: []interface{}{simpleDialQueue}}
+	sliceSimpleDialQueue := []interface{}{sdqDial}
+
+	fullDialQueue := &DialQueue{
+		QueueName:           "Testing",
+		URL:                 "https://example.org/url",
+		Method:              "POST",
+		ReservationSID:      "reservationSid",
+		PostWorkActivitySID: "postWorkActivitySid",
+	}
+	fdqDial := &Dial{Nouns: []interface{}{fullDialQueue}}
+	sliceFullDialQueue := []interface{}{fdqDial}
+
+	fullDialSIM := &DialSIM{SIM: "Testing"}
+	fdsDial := &Dial{Nouns: []interface{}{fullDialSIM}}
+	sliceFullDialSIM := []interface{}{fdsDial}
+
+	simpleDialNumber := &DialNumber{Number: "+14155555555"}
+	sdnDial := &Dial{Nouns: []interface{}{simpleDialNumber}}
+	sliceSimpleDialNumber := []interface{}{sdnDial}
+
+	fullDialNumber := &DialNumber{
+		Number:               "+14155555555",
+		SendDigits:           "ww42",
+		URL:                  "https://example.org/url",
+		Method:               "POST",
+		StatusCallbackEvent:  StatusCallbackAll,
+		StatusCallback:       "https://example.org/scb",
+		StatusCallbackMethod: "POST",
+	}
+	fdnDial := &Dial{Nouns: []interface{}{fullDialNumber}}
+	sliceFullDialNumber := []interface{}{fdnDial}
+
+	simpleDialConference := &DialConference{Name: "testConf"}
+	sdconfDial := &Dial{Nouns: []interface{}{simpleDialConference}}
+	sliceSimpleDialConference := []interface{}{sdconfDial}
+
+	fullDialConference := &DialConference{
+		Name:  "testConf",
+		Muted: true,
+		Beep:  ConfBeepTrue,
+		StartConferenceOnEnter:        ConfStartOnEnterTrue,
+		EndConferenceOnExit:           true,
+		WaitURL:                       "https://example.org/wait",
+		WaitMethod:                    "POST",
+		MaxParticipants:               42, // because Twilio doesn't allow tree-fiddy
+		Record:                        ConfRecordFromStart,
+		Region:                        ConfRegionJapan,
+		Trim:                          TrimSilence,
+		Whisper:                       "testWhisper",
+		StatusCallbackEvent:           ConfStatusCallbackAll,
+		StatusCallbackMethod:          "POST",
+		RecordingStatusCallback:       "https://example.org/rsc",
+		RecordingStatusCallbackMethod: "POST",
+	}
+	fdconfDial := &Dial{Nouns: []interface{}{fullDialConference}}
+	sliceFullDialConference := []interface{}{fdconfDial}
+
+	simpleDialSIP := &DialSIP{URI: "Testing"}
+	sdsipDial := &Dial{Nouns: []interface{}{simpleDialSIP}}
+	sliceSimpleDialSIP := []interface{}{sdsipDial}
+
+	fullDialSIP := &DialSIP{
+		URI:                  "Testing",
+		Username:             "testUser",
+		Password:             "testPass",
+		URL:                  "https://example.org/url",
+		Method:               "POST",
+		StatusCallbackEvent:  StatusCallbackAll,
+		StatusCallback:       "https://example.org/scb",
+		StatusCallbackMethod: "POST",
+		Timeout:              42,
+		HangupOnStar:         true,
+		TimeLimit:            84,
+		CallerID:             "theckman",
+		Record:               DialRecordFromRingingDual,
+		Trim:                 TrimSilence,
+		RecordingStatusCallback:       "https://example.org/rscb",
+		RecordingStatusCallbackMethod: "POST",
+		AnswerOnBridge:                true,
+		RingTone:                      RingToneJapan,
+	}
+	fdsipDial := &Dial{Nouns: []interface{}{fullDialSIP}}
+	sliceFullDialSIP := []interface{}{fdsipDial}
+
+	dialWithNouns := &Dial{Nouns: []interface{}{fullDialSIP, fullDialQueue}}
+	sliceDialWithNouns := []interface{}{dialWithNouns}
+
+	anotherSimpleSay := &Say{Message: "Goodbye!"}
+	anotherFullSay := &Say{
+		Message:  "Goodbye!",
+		Language: LangEnglishAustralia,
+		Loop:     3,
+		Voice:    VoiceAlice,
+	}
+
+	sliceSimple := []interface{}{
+		simpleSay, simpleRecord, simpleReject, fullHangup,
+		simplePlay, simplePause, simpleSms, simpleRedirect,
+		fullLeave, simpleEnqueue, simpleGather, simpleDial,
+		anotherSimpleSay,
+	}
+
+	sliceFull := []interface{}{
+		fullSay, fullRecord, fullReject, fullHangup,
+		fullPlay, fullPause, fullSms, fullRedirect,
+		fullLeave, fullEnqueue, fullGather, fullDial,
+		anotherFullSay,
+	}
+
+	//
+	// Test loop
+	//
+	tests := []struct {
+		desc        string
+		in          []interface{}
+		outfilePath string
+	}{
+		{"Response with one simple <Say> instruction", sliceSimpleSay, "simplesay.xml"},
+		{"Response with one full <Say> instruction", sliceFullSay, "fullsay.xml"},
+		{"Response with one simple <Record> instruction", sliceSimpleRecord, "simplerecord.xml"},
+		{"Response with one full <Record> instruction", sliceFullRecord, "fullrecord.xml"},
+		{"Response with one simple <Reject> instruction", sliceSimpleReject, "simplereject.xml"},
+		{"Response with one full <Reject> instruction", sliceFullReject, "fullreject.xml"},
+		{"Response with one full <Hangup> instruction", sliceFullHangup, "fullhangup.xml"},
+		{"Response with one simple <Play> instruction", sliceSimplePlay, "simpleplay.xml"},
+		{"Response with one full <Play> instruction", sliceFullPlay, "fullplay.xml"},
+		{"Response with one simple <Pause> instruction", sliceSimplePause, "simplepause.xml"},
+		{"Response with one full <Pause> instruction", sliceFullPause, "fullpause.xml"},
+		{"Response with one simple <Sms> instruction", sliceSimpleSms, "simplesms.xml"},
+		{"Response with one full <Sms> instruction", sliceFullSms, "fullsms.xml"},
+		{"Response with one simple <Redirect> instruction", sliceSimpleRedirect, "simpleredirect.xml"},
+		{"Response with one full <Redirect> instruction", sliceFullRedirect, "fullredirect.xml"},
+		{"Response with one full <Leave> instruction", sliceFullLeave, "fullleave.xml"},
+		{"Response with one simple <Enqueue> instruction", sliceSimpleEnqueue, "simpleenqueue.xml"},
+		{"Response with one full <Enqueue> instruction", sliceFullEnqueue, "fullenqueue.xml"},
+		{"Response with one full <Enqueue> instruction with a Task", sliceFullEnqueueWithTask, "fullenqueuewithtask.xml"},
+		{"Response with one simple <Gather> instruction", sliceSimpleGather, "simplegather.xml"},
+		{"Response with one full <Gather> instruction", sliceFullGather, "fullgather.xml"},
+		{"Response with one full <Gather> instruction with verbs", sliceFullGatherWithVerbs, "fullgatherwithverbs.xml"},
+		{"Response with one simple <Dial> instruction", sliceSimpleDial, "simpledial.xml"},
+		{"Response with one full <Dial> instruction", sliceFullDial, "fulldial.xml"},
+		{"Response with one simple <Dial><Client> instruction", sliceSimpleDialClient, "simpleDialClient.xml"},
+		{"Response with one full <Dial><Client> instruction", sliceFullDialClient, "fullDialClient.xml"},
+		{"Response with one simple <Dial><Queue> instruction", sliceSimpleDialQueue, "simpleDialQueue.xml"},
+		{"Response with one full <Dial><Queue> instruction", sliceFullDialQueue, "fullDialQueue.xml"},
+		{"Response with one full <Dial><Sim> instruction", sliceFullDialSIM, "fullDialSIM.xml"},
+		{"Response with one simple <Dial><Number> instruction", sliceSimpleDialNumber, "simpleDialNumber.xml"},
+		{"Response with one full <Dial><Number> instruction", sliceFullDialNumber, "fullDialNumber.xml"},
+		{"Response with one simple <Dial><Conference> instruction", sliceSimpleDialConference, "simpleDialConference.xml"},
+		{"Response with one full <Dial><Conference> instruction", sliceFullDialConference, "fullDialConference.xml"},
+		{"Response with one simple <Dial><Sip> instruction", sliceSimpleDialSIP, "simpleDialSIP.xml"},
+		{"Response with one full <Dial><Sip> instruction", sliceFullDialSIP, "fullDialSIP.xml"},
+		{"Response with one <Dial> with multiple nouns instruction", sliceDialWithNouns, "fullDialWithNouns.xml"},
+		{"Response with all simple instructions", sliceSimple, "simple.xml"},
+		{"Response with all full instructions", sliceFull, "full.xml"},
+	}
+
+	for _, test := range tests {
+		tdPath := filepath.Join("testdata", test.outfilePath)
+		testExpectedOut, err := readFileString(tdPath)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nUnexpected error reading testdata file (%s): %s",
+				test.desc, tdPath, err.Error(),
+			)
+			continue
+		}
+
+		b := &bytes.Buffer{}
+
+		err = EncodeSlice(b, test.in)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nEncodeResponse() Unexpected Error: %s",
+				test.desc, err,
+			)
+			continue
+		}
+
+		if out := b.String(); out != testExpectedOut {
+			t.Errorf(
+				"\nDescription: %s\nRendered XML (quoted with `):\n`%s`\n\nWant XML (quoted with `):\n`%s`",
+				test.desc, out, testExpectedOut,
+			)
+			continue
+		}
+	}
+}
+
+func TestMarshalSlice(t *testing.T) {
+	simpleSay := &Say{Message: "Testing!"}
+	fullSay := &Say{
+		Message:  "Testing!",
+		Language: LangEnglishUS,
+		Loop:     2,
+		Voice:    VoiceAlice,
+	}
+	sliceSimpleSay := []interface{}{simpleSay}
+	sliceFullSay := []interface{}{fullSay}
+
+	simpleRecord := &Record{}
+	fullRecord := &Record{
+		Action:      "https://example.org/action",
+		Method:      "POST",
+		Timeout:     3,
+		FinishOnKey: FinishKeyAll,
+		MaxLength:   350,
+		PlayBeep:    true,
+		Trim:        TrimSilence,
+		RecordingStatusCallback:       "https://example.org/rsc",
+		RecordingStatusCallbackMethod: "POST",
+		Transcribe:                    true,
+		TranscribeCallback:            "https://example.org/tc",
+	}
+	sliceSimpleRecord := []interface{}{simpleRecord}
+	sliceFullRecord := []interface{}{fullRecord}
+
+	simpleReject := &Reject{}
+	fullReject := &Reject{Reason: RejectReasonRejected}
+	sliceSimpleReject := []interface{}{simpleReject}
+	sliceFullReject := []interface{}{fullReject}
+
+	fullHangup := &Hangup{}
+	sliceFullHangup := []interface{}{fullHangup}
+
+	simplePlay := &Play{URL: "https://example.org/audio.mp3"}
+	fullPlay := &Play{
+		URL:    "https://example.org/audio.mp3",
+		Loop:   2,
+		Digits: "0w42*",
+	}
+	sliceSimplePlay := []interface{}{simplePlay}
+	sliceFullPlay := []interface{}{fullPlay}
+
+	simplePause := &Pause{}
+	fullPause := &Pause{Length: 4}
+
+	sliceSimplePause := []interface{}{simplePause}
+	sliceFullPause := []interface{}{fullPause}
+
+	simpleSms := &Sms{Message: "Test message!"}
+	fullSms := &Sms{
+		Message:        "Test message!",
+		To:             "+14155555555",
+		From:           "+14155555656",
+		Action:         "https://example.org/action",
+		Method:         "POST",
+		StatusCallback: "https://example.org/scb",
+	}
+
+	sliceSimpleSms := []interface{}{simpleSms}
+	sliceFullSms := []interface{}{fullSms}
+
+	simpleRedirect := &Redirect{URL: "https://example.org/redirect"}
+	fullRedirect := &Redirect{
+		URL:    "https://example.org/redirect",
+		Method: "POST",
+	}
+
+	sliceSimpleRedirect := []interface{}{simpleRedirect}
+	sliceFullRedirect := []interface{}{fullRedirect}
+
+	fullLeave := &Leave{}
+	sliceFullLeave := []interface{}{fullLeave}
+
+	simpleEnqueue := &Enqueue{QueueName: "test"}
+	fullEnqueue := &Enqueue{
+		QueueName:     "test",
+		Action:        "https://example.org/action",
+		Method:        "POST",
+		WaitURL:       "https://example.org/wait",
+		WaitURLMethod: "GET",
+		WorkflowSID:   "WWtesting",
+	}
+
+	fullEnqueueWithTask := &Enqueue{
+		QueueName:     "test",
+		Task:          `{"test":"obj"}`,
+		Action:        "https://example.org/action",
+		Method:        "POST",
+		WaitURL:       "https://example.org/wait",
+		WaitURLMethod: "GET",
+		WorkflowSID:   "WWtesting",
+	}
+
+	sliceSimpleEnqueue := []interface{}{simpleEnqueue}
+	sliceFullEnqueue := []interface{}{fullEnqueue}
+	sliceFullEnqueueWithTask := []interface{}{fullEnqueueWithTask}
+
+	simpleGather := &Gather{}
+	fullGather := &Gather{
+		Input:                       GatherInputDTMFSpeech,
+		Action:                      "https://example.org/action",
+		Method:                      "POST",
+		Timeout:                     5,
+		FinishOnKey:                 FinishKeyStar | FinishKeyPound,
+		NumDigits:                   42,
+		PartialResultCallback:       "https://example.org/prc",
+		PartialResultCallbackMethod: "POST",
+		Language:                    LangEnglishUS,
+		Hints:                       "bacon ipsum, other stuff",
+		BargeIn:                     BargeInFalse,
+	}
+	fullGatherWithVerbs := &Gather{
+		Input:                       GatherInputDTMFSpeech,
+		Action:                      "https://example.org/action",
+		Method:                      "POST",
+		Timeout:                     5,
+		FinishOnKey:                 FinishKeyStar | FinishKeyPound,
+		NumDigits:                   42,
+		PartialResultCallback:       "https://example.org/prc",
+		PartialResultCallbackMethod: "POST",
+		Language:                    LangEnglishUS,
+		Hints:                       "bacon ipsum, other stuff",
+		BargeIn:                     BargeInFalse,
+		NestedVerbs: []interface{}{
+			fullSay, fullPlay, fullPause,
+		},
+	}
+
+	sliceSimpleGather := []interface{}{simpleGather}
+	sliceFullGather := []interface{}{fullGather}
+	sliceFullGatherWithVerbs := []interface{}{fullGatherWithVerbs}
+
+	simpleDial := &Dial{Number: "415-555-5555"}
+	fullDial := &Dial{
+		Number:       "415-555-5555",
+		Action:       "https://example.org/action",
+		Method:       "POST",
+		Timeout:      5,
+		HangupOnStar: true,
+		TimeLimit:    10,
+		CallerID:     "+14155555555",
+		Record:       DialRecordFromRingingDual,
+		Trim:         TrimSilence,
+		RecordingStatusCallback:       "https://example.org/rsc",
+		RecordingStatusCallbackMethod: "POST",
+		AnswerOnBridge:                true,
+		RingTone:                      RingToneUSOld,
+	}
+
+	sliceSimpleDial := []interface{}{simpleDial}
+	sliceFullDial := []interface{}{fullDial}
+
+	simpleDialClient := &DialClient{ClientName: "Testing"}
+	sdcDial := &Dial{Nouns: []interface{}{simpleDialClient}}
+	sliceSimpleDialClient := []interface{}{sdcDial}
+
+	fullDialClient := &DialClient{
+		ClientName:           "Testing",
+		URL:                  "https://example.org/url",
+		Method:               "POST",
+		StatusCallbackEvent:  StatusCallbackAll,
+		StatusCallback:       "https://example.org/scb",
+		StatusCallbackMethod: "POST",
+	}
+	fdcDial := &Dial{Nouns: []interface{}{fullDialClient}}
+	sliceFullDialClient := []interface{}{fdcDial}
+
+	simpleDialQueue := &DialQueue{QueueName: "Testing"}
+	sdqDial := &Dial{Nouns: []interface{}{simpleDialQueue}}
+	sliceSimpleDialQueue := []interface{}{sdqDial}
+
+	fullDialQueue := &DialQueue{
+		QueueName:           "Testing",
+		URL:                 "https://example.org/url",
+		Method:              "POST",
+		ReservationSID:      "reservationSid",
+		PostWorkActivitySID: "postWorkActivitySid",
+	}
+	fdqDial := &Dial{Nouns: []interface{}{fullDialQueue}}
+	sliceFullDialQueue := []interface{}{fdqDial}
+
+	fullDialSIM := &DialSIM{SIM: "Testing"}
+	fdsDial := &Dial{Nouns: []interface{}{fullDialSIM}}
+	sliceFullDialSIM := []interface{}{fdsDial}
+
+	simpleDialNumber := &DialNumber{Number: "+14155555555"}
+	sdnDial := &Dial{Nouns: []interface{}{simpleDialNumber}}
+	sliceSimpleDialNumber := []interface{}{sdnDial}
+
+	fullDialNumber := &DialNumber{
+		Number:               "+14155555555",
+		SendDigits:           "ww42",
+		URL:                  "https://example.org/url",
+		Method:               "POST",
+		StatusCallbackEvent:  StatusCallbackAll,
+		StatusCallback:       "https://example.org/scb",
+		StatusCallbackMethod: "POST",
+	}
+	fdnDial := &Dial{Nouns: []interface{}{fullDialNumber}}
+	sliceFullDialNumber := []interface{}{fdnDial}
+
+	simpleDialConference := &DialConference{Name: "testConf"}
+	sdconfDial := &Dial{Nouns: []interface{}{simpleDialConference}}
+	sliceSimpleDialConference := []interface{}{sdconfDial}
+
+	fullDialConference := &DialConference{
+		Name:  "testConf",
+		Muted: true,
+		Beep:  ConfBeepTrue,
+		StartConferenceOnEnter:        ConfStartOnEnterTrue,
+		EndConferenceOnExit:           true,
+		WaitURL:                       "https://example.org/wait",
+		WaitMethod:                    "POST",
+		MaxParticipants:               42, // because Twilio doesn't allow tree-fiddy
+		Record:                        ConfRecordFromStart,
+		Region:                        ConfRegionJapan,
+		Trim:                          TrimSilence,
+		Whisper:                       "testWhisper",
+		StatusCallbackEvent:           ConfStatusCallbackAll,
+		StatusCallbackMethod:          "POST",
+		RecordingStatusCallback:       "https://example.org/rsc",
+		RecordingStatusCallbackMethod: "POST",
+	}
+	fdconfDial := &Dial{Nouns: []interface{}{fullDialConference}}
+	sliceFullDialConference := []interface{}{fdconfDial}
+
+	simpleDialSIP := &DialSIP{URI: "Testing"}
+	sdsipDial := &Dial{Nouns: []interface{}{simpleDialSIP}}
+	sliceSimpleDialSIP := []interface{}{sdsipDial}
+
+	fullDialSIP := &DialSIP{
+		URI:                  "Testing",
+		Username:             "testUser",
+		Password:             "testPass",
+		URL:                  "https://example.org/url",
+		Method:               "POST",
+		StatusCallbackEvent:  StatusCallbackAll,
+		StatusCallback:       "https://example.org/scb",
+		StatusCallbackMethod: "POST",
+		Timeout:              42,
+		HangupOnStar:         true,
+		TimeLimit:            84,
+		CallerID:             "theckman",
+		Record:               DialRecordFromRingingDual,
+		Trim:                 TrimSilence,
+		RecordingStatusCallback:       "https://example.org/rscb",
+		RecordingStatusCallbackMethod: "POST",
+		AnswerOnBridge:                true,
+		RingTone:                      RingToneJapan,
+	}
+	fdsipDial := &Dial{Nouns: []interface{}{fullDialSIP}}
+	sliceFullDialSIP := []interface{}{fdsipDial}
+
+	dialWithNouns := &Dial{Nouns: []interface{}{fullDialSIP, fullDialQueue}}
+	sliceDialWithNouns := []interface{}{dialWithNouns}
+
+	anotherSimpleSay := &Say{Message: "Goodbye!"}
+	anotherFullSay := &Say{
+		Message:  "Goodbye!",
+		Language: LangEnglishAustralia,
+		Loop:     3,
+		Voice:    VoiceAlice,
+	}
+
+	sliceSimple := []interface{}{
+		simpleSay, simpleRecord, simpleReject, fullHangup,
+		simplePlay, simplePause, simpleSms, simpleRedirect,
+		fullLeave, simpleEnqueue, simpleGather, simpleDial,
+		anotherSimpleSay,
+	}
+
+	sliceFull := []interface{}{
+		fullSay, fullRecord, fullReject, fullHangup,
+		fullPlay, fullPause, fullSms, fullRedirect,
+		fullLeave, fullEnqueue, fullGather, fullDial,
+		anotherFullSay,
+	}
+
+	//
+	// Test loop
+	//
+	tests := []struct {
+		desc        string
+		in          []interface{}
+		outfilePath string
+	}{
+		{"Response with one simple <Say> instruction", sliceSimpleSay, "simplesay.xml"},
+		{"Response with one full <Say> instruction", sliceFullSay, "fullsay.xml"},
+		{"Response with one simple <Record> instruction", sliceSimpleRecord, "simplerecord.xml"},
+		{"Response with one full <Record> instruction", sliceFullRecord, "fullrecord.xml"},
+		{"Response with one simple <Reject> instruction", sliceSimpleReject, "simplereject.xml"},
+		{"Response with one full <Reject> instruction", sliceFullReject, "fullreject.xml"},
+		{"Response with one full <Hangup> instruction", sliceFullHangup, "fullhangup.xml"},
+		{"Response with one simple <Play> instruction", sliceSimplePlay, "simpleplay.xml"},
+		{"Response with one full <Play> instruction", sliceFullPlay, "fullplay.xml"},
+		{"Response with one simple <Pause> instruction", sliceSimplePause, "simplepause.xml"},
+		{"Response with one full <Pause> instruction", sliceFullPause, "fullpause.xml"},
+		{"Response with one simple <Sms> instruction", sliceSimpleSms, "simplesms.xml"},
+		{"Response with one full <Sms> instruction", sliceFullSms, "fullsms.xml"},
+		{"Response with one simple <Redirect> instruction", sliceSimpleRedirect, "simpleredirect.xml"},
+		{"Response with one full <Redirect> instruction", sliceFullRedirect, "fullredirect.xml"},
+		{"Response with one full <Leave> instruction", sliceFullLeave, "fullleave.xml"},
+		{"Response with one simple <Enqueue> instruction", sliceSimpleEnqueue, "simpleenqueue.xml"},
+		{"Response with one full <Enqueue> instruction", sliceFullEnqueue, "fullenqueue.xml"},
+		{"Response with one full <Enqueue> instruction with a Task", sliceFullEnqueueWithTask, "fullenqueuewithtask.xml"},
+		{"Response with one simple <Gather> instruction", sliceSimpleGather, "simplegather.xml"},
+		{"Response with one full <Gather> instruction", sliceFullGather, "fullgather.xml"},
+		{"Response with one full <Gather> instruction with verbs", sliceFullGatherWithVerbs, "fullgatherwithverbs.xml"},
+		{"Response with one simple <Dial> instruction", sliceSimpleDial, "simpledial.xml"},
+		{"Response with one full <Dial> instruction", sliceFullDial, "fulldial.xml"},
+		{"Response with one simple <Dial><Client> instruction", sliceSimpleDialClient, "simpleDialClient.xml"},
+		{"Response with one full <Dial><Client> instruction", sliceFullDialClient, "fullDialClient.xml"},
+		{"Response with one simple <Dial><Queue> instruction", sliceSimpleDialQueue, "simpleDialQueue.xml"},
+		{"Response with one full <Dial><Queue> instruction", sliceFullDialQueue, "fullDialQueue.xml"},
+		{"Response with one full <Dial><Sim> instruction", sliceFullDialSIM, "fullDialSIM.xml"},
+		{"Response with one simple <Dial><Number> instruction", sliceSimpleDialNumber, "simpleDialNumber.xml"},
+		{"Response with one full <Dial><Number> instruction", sliceFullDialNumber, "fullDialNumber.xml"},
+		{"Response with one simple <Dial><Conference> instruction", sliceSimpleDialConference, "simpleDialConference.xml"},
+		{"Response with one full <Dial><Conference> instruction", sliceFullDialConference, "fullDialConference.xml"},
+		{"Response with one simple <Dial><Sip> instruction", sliceSimpleDialSIP, "simpleDialSIP.xml"},
+		{"Response with one full <Dial><Sip> instruction", sliceFullDialSIP, "fullDialSIP.xml"},
+		{"Response with one <Dial> with multiple nouns instruction", sliceDialWithNouns, "fullDialWithNouns.xml"},
+		{"Response with all simple instructions", sliceSimple, "simple.xml"},
+		{"Response with all full instructions", sliceFull, "full.xml"},
+	}
+
+	for _, test := range tests {
+		tdPath := filepath.Join("testdata", test.outfilePath)
+		testExpectedOut, err := readFileString(tdPath)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nUnexpected error reading testdata file (%s): %s",
+				test.desc, tdPath, err.Error(),
+			)
+			continue
+		}
+
+		renderedXML, err := MarshalSlice(test.in)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nEncodeResponse() Unexpected Error: %s",
+				test.desc, err,
+			)
+			continue
+		}
+
+		if out := string(renderedXML); out != testExpectedOut {
+			t.Errorf(
+				"\nDescription: %s\nRendered XML (quoted with `):\n`%s`\n\nWant XML (quoted with `):\n`%s`",
+				test.desc, out, testExpectedOut,
+			)
+			continue
+		}
+	}
+}

--- a/twiml/verbs.go
+++ b/twiml/verbs.go
@@ -1,0 +1,167 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+)
+
+// The Dial verb connects the current caller to another phone. If the called
+// party picks up, the two parties are connected and can communicate until one
+// hangs up. If the called party does not pick up, if a busy signal is received,
+// or if the number doesn't exist, the dial verb will finish.
+//
+// When the dialed call ends, Twilio makes a GET or POST request to the 'action'
+// URL if provided. Call flow will continue using the TwiML received in response
+// to that request.
+type Dial struct {
+	XMLName                       xml.Name   `xml:"Dial"`
+	Number                        string     `xml:",chardata"`
+	Action                        string     `xml:"action,attr,omitempty"`
+	Method                        string     `xml:"method,attr,omitempty"`
+	Timeout                       uint       `xml:"timeout,attr,omitempty"`
+	HangupOnStar                  bool       `xml:"hangupOnStar,attr"`
+	TimeLimit                     uint       `xml:"timeLimit,attr,omitempty"`
+	CallerID                      string     `xml:"callerId,attr,omitempty"`
+	Record                        DialRecord `xml:"record,attr,omitempty"`
+	Trim                          Trim       `xml:"trim,attr,omitempty"`
+	RecordingStatusCallback       string     `xml:"recordingStatusCallback,attr,omitempty"`
+	RecordingStatusCallbackMethod string     `xml:"recordingStatusCallbackMethod,attr,omitempty"`
+	AnswerOnBridge                bool       `xml:"answerOnBridge,attr"`
+	RingTone                      RingTone   `xml:"ringTone,attr,omitempty"`
+	Nouns                         []interface{}
+}
+
+// The Enqueue verb enqueues the current call in a call queue. Enqueued calls
+// wait in hold music until the call is dequeued by another caller via the
+// Dial verb or transfered out of the queue via the REST API or the Leave
+// verb.
+//
+// The Enqueue verb will create a queue on demand, if the queue does not already
+// exist. The default maximum length of the queue is 100. This can be modified
+// using the REST API.
+type Enqueue struct {
+	XMLName       xml.Name `xml:"Enqueue"`
+	QueueName     string   `xml:",chardata"`
+	Task          string   `xml:"Task,omitempty"`
+	Action        string   `xml:"action,attr,omitempty"`
+	Method        string   `xml:"method,attr,omitempty"`
+	WaitURL       string   `xml:"waitUrl,attr,omitempty"`
+	WaitURLMethod string   `xml:"waitUrlMethod,attr,omitempty"`
+	WorkflowSID   string   `xml:"workflowSid,attr,omitempty"`
+}
+
+// The Gather verb collects digits or transcribes speech from a caller, when the
+// caller is done entering digits or speaking, Twilio submits that data to the
+// provided 'action' URL in an HTTP GET or POST request, just like a web browser
+// submits data from an HTML form.
+type Gather struct {
+	XMLName                     xml.Name    `xml:"Gather"`
+	Input                       GatherInput `xml:"input,attr,omitempty"`
+	Action                      string      `xml:"action,attr,omitempty"`
+	Method                      string      `xml:"method,attr,omitempty"`
+	Timeout                     uint        `xml:"timeout,attr,omitempty"`
+	FinishOnKey                 FinishOnKey `xml:"finishOnKey,attr,omitempty"`
+	NumDigits                   uint        `xml:"numDigits,attr,omitempty"`
+	PartialResultCallback       string      `xml:"partialResultCallback,attr,omitempty"`
+	PartialResultCallbackMethod string      `xml:"partialResultCallbackMethod,attr,omitempty"`
+	Language                    Language    `xml:"language,attr,omitempty"`
+	Hints                       string      `xml:"hints,attr,omitempty"`
+	BargeIn                     BargeIn     `xml:"bargeIn,attr,omitempty"`
+
+	// NestedVerbs within Gather can only contain these three verb types: Say,
+	// Play, and Pause. Other types may be rejected by the Twilio TwiML parser.
+	NestedVerbs []interface{}
+}
+
+// The Hangup verb ends a call. If used as the first verb in a TwiML response it
+// does not prevent Twilio from answering the call and billing your account. The
+// only way to not answer a call and prevent billing is to use the Reject verb.
+type Hangup struct {
+	XMLName xml.Name `xml:"Hangup"`
+}
+
+// The Leave verb transfers control of a call that is in a queue so that the
+// caller exits the queue and execution continues with the next verb after the
+// original Enqueue.
+type Leave struct {
+	XMLName xml.Name `xml:"Leave"`
+}
+
+// The Pause verb waits silently for a specific number of seconds. If Pause is
+// the first verb in a TwiML document, Twilio will wait the specified number of
+// seconds before picking up the call.
+type Pause struct {
+	XMLName xml.Name `xml:"Pause"`
+	Length  uint     `xml:"length,attr,omitempty"`
+}
+
+// Play is play
+type Play struct {
+	XMLName xml.Name `xml:"Play"`
+	URL     string   `xml:",chardata"`
+	Loop    uint     `xml:"loop,attr,omitempty"`
+	Digits  string   `xml:"digits,attr,omitempty"`
+}
+
+// The Record verb records the caller's voice and returns to you the URL of a
+// file containing the audio recording. You can optionally generate text
+// transcriptions of recorded calls by setting the Transcribe field of the
+// Record struct to 'true'.
+type Record struct {
+	XMLName                       xml.Name    `xml:"Record"`
+	Action                        string      `xml:"action,attr,omitempty"`
+	Method                        string      `xml:"method,attr,omitempty"`
+	Timeout                       uint        `xml:"timeout,attr,omitempty"`
+	FinishOnKey                   FinishOnKey `xml:"finishOnKey,attr,omitempty"`
+	MaxLength                     uint        `xml:"maxLength,attr,omitempty"`
+	PlayBeep                      bool        `xml:"playBeep,attr,omitempty"`
+	Trim                          Trim        `xml:"trim,attr,omitempty"`
+	RecordingStatusCallback       string      `xml:"recordingStatusCallback,attr,omitempty"`
+	RecordingStatusCallbackMethod string      `xml:"recordingStatusCallbackMethod,attr,omitempty"`
+	Transcribe                    bool        `xml:"transcribe,attr"`
+	TranscribeCallback            string      `xml:"transcribeCallback,attr,omitempty"`
+}
+
+// The Redirect verb transfers control of a call to the TwiML at a different
+// URL. All verbs after Redirect are unreachable and ignored.
+type Redirect struct {
+	XMLName xml.Name `xml:"Redirect"`
+	URL     string   `xml:",chardata"`
+	Method  string   `xml:"method,attr,omitempty"`
+}
+
+// The Reject verb rejects an incoming call to your Twilio number without
+// billing you.
+type Reject struct {
+	XMLName xml.Name     `xml:"Reject"`
+	Reason  RejectReason `xml:"reason,attr,omitempty"`
+}
+
+// The Say verb converts text to speech that is read back to the caller. Say is
+// useful for development or saying dynamic text that is difficult to
+// pre-record. The current verb offers different options for voices, each with
+// its own supported set of languages and genders, so configure your TwiML
+// depending on preferred gender and language combination.
+type Say struct {
+	XMLName  xml.Name `xml:"Say"`
+	Message  string   `xml:",chardata"`
+	Language Language `xml:"language,attr,omitempty"`
+	Loop     uint     `xml:"loop,attr,omitempty"`
+	Voice    Voice    `xml:"voice,attr,omitempty"`
+}
+
+// The Sms verb sends an SMS message to a phone number during a phone call.
+type Sms struct {
+	XMLName        xml.Name `xml:"Sms"`
+	Message        string   `xml:",chardata"`
+	To             string   `xml:"to,attr,omitempty"`
+	From           string   `xml:"from,attr,omitempty"`
+	Action         string   `xml:"action,attr,omitempty"`
+	Method         string   `xml:"method,attr,omitempty"`
+	StatusCallback string   `xml:"statusCallback,attr,omitempty"`
+}

--- a/twiml/voice.go
+++ b/twiml/voice.go
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import "encoding/xml"
+
+// Voice is the voices that are available as part of the Twilio Text to Speech
+// engine using in calls. The default voice is Alice as it has better support
+// for languages.
+type Voice uint8
+
+const (
+	// VoiceDefault is the default vault for which Voice to use. This
+	// effectively renders an empty string / no value to have the default of the
+	// API be used.
+	VoiceDefault Voice = iota
+
+	// VoiceAlice is the default voice, named Alice. It has the best support for
+	// languages.
+	VoiceAlice
+
+	// VoiceMan is the legacy male voice. It only supports the legacy languages.
+	VoiceMan
+
+	// VoiceWoman is the legacy female voice. It only supports the legacy languages.
+	VoiceWoman
+)
+
+// MarshalXMLAttr implements the xml.MarshalerAttr interface.
+func (v Voice) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	attr := xml.Attr{
+		Name:  name,
+		Value: v.String(),
+	}
+
+	return attr, nil
+}
+
+func (v Voice) String() string {
+	switch v {
+	case VoiceDefault:
+		return ""
+	case VoiceAlice:
+		return "alice"
+	case VoiceMan:
+		return "man"
+	case VoiceWoman:
+		return "woman"
+	default:
+		return "unknown"
+	}
+}

--- a/twiml/voice_test.go
+++ b/twiml/voice_test.go
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, you can
+// obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2017 Tim Heckman
+
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestVoice_String(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   Voice
+		out  string
+	}{
+		{"Default (Zero Vault) voice should empty string", Voice(0), ""},
+		{"VoiceDefault voice should be empty string", VoiceDefault, ""},
+		{"VoiceAlice voice should be Alice", VoiceAlice, "alice"},
+		{"VoiceMan voice should be Alice", VoiceMan, "man"},
+		{"VoiceWoman voice should be Alice", VoiceWoman, "woman"},
+	}
+
+	var out string
+
+	for _, test := range tests {
+		out = test.in.String()
+
+		if out != test.out {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).String() = %q; want %q",
+				test.desc, test.in, out, test.out,
+			)
+		}
+	}
+}
+
+func TestVoice_MarshalXMLAttr(t *testing.T) {
+	attrName := xml.Name{Local: "voice"}
+
+	tests := []struct {
+		desc     string
+		in       Voice
+		inName   xml.Name
+		outName  xml.Name
+		outValue string
+	}{
+		{"Default (Zero Vault) voice should empty string", Voice(0), attrName, attrName, ""},
+		{"VoiceAlice voice should be Alice", VoiceAlice, attrName, attrName, "alice"},
+		{"VoiceMan voice should be Alice", VoiceMan, attrName, attrName, "man"},
+		{"VoiceWoman voice should be Alice", VoiceWoman, attrName, attrName, "woman"},
+	}
+
+	var out xml.Attr
+	var err error
+
+	for _, test := range tests {
+		out, err = test.in.MarshalXMLAttr(test.inName)
+
+		if err != nil {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v) Error: %s",
+				test.desc, test.in, test.inName, err,
+			)
+		}
+
+		if out.Name.Space != test.outName.Space || out.Name.Local != test.outName.Local {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Name = %#v; want %#v",
+				test.desc, test.in, test.inName, out.Name, test.outName,
+			)
+		}
+
+		if out.Value != test.outValue {
+			t.Errorf(
+				"\nDescription: %s\nVoice(%d).MarshalAttr(%#v).Value = %q; want %q",
+				test.desc, test.in, test.inName, out.Value, test.outValue,
+			)
+		}
+	}
+}


### PR DESCRIPTION
Twilio has their own XML-based Markup Language called TwiML. This markup is used
when sending and receiving phone calls using Twilio. It gives Twilio
instructions on how to handle and route the call, as well as what to do once the
call has been answered (such as saying something).

This package introduces the ability to render all aspects of TwiML to allow
users to do this in a way that feels idiomatic.