### PR TITLE
Add error checking around xmlHeader write to io.Writer

### DIFF
--- a/twiml/twiml.go
+++ b/twiml/twiml.go
@@ -36,7 +36,9 @@ func EncodeResponse(w io.Writer, r *Response) error {
 	encoder.Indent("", "  ")
 
 	// write the xml header to the buffer
-	w.Write(xmlHeader)
+	if _, err := w.Write(xmlHeader); err != nil {
+		return err
+	}
 
 	// encode the *Response in to XML and write it to the buffer
 	if err := encoder.Encode(r); err != nil {


### PR DESCRIPTION
It makes sense to do error checking on write to the io.Writer in
EncodeResponse(). This change adds that.